### PR TITLE
feat: add provider abstraction for multi-agent support

### DIFF
--- a/src/components/ConversationView.tsx
+++ b/src/components/ConversationView.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const ConversationView: React.FC<Props> = React.memo(({ messages, phase }) => {
 	// Layout constants - max 88 characters per line
-	const MAX_LINE_WIDTH = 88;
+	const _MAX_LINE_WIDTH = 88;
 	const DRIVER_WIDTH = 84; // characters for driver messages
 	const SYSTEM_WIDTH = 88; // characters for system messages
 	const SEPARATOR = "-".repeat(60);

--- a/src/components/ConversationView.tsx
+++ b/src/components/ConversationView.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "ink";
 import React, { useCallback, useMemo } from "react";
-import type { Message } from "../types.js";
+import type { Message, SessionPhase } from "../types.js";
 import DriverMessage from "./DriverMessage.js";
 import GenericMessage from "./GenericMessage.js";
 import NavigatorMessage from "./NavigatorMessage.js";
@@ -8,7 +8,7 @@ import SystemMessage from "./SystemMessage.js";
 
 interface Props {
 	messages: Message[];
-	phase?: "planning" | "execution" | "review" | "complete";
+	phase?: SessionPhase;
 }
 
 const ConversationView: React.FC<Props> = React.memo(({ messages, phase }) => {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,11 @@
 import { Box, Text, useInput } from "ink";
 import type React from "react";
 import { hasAbsolutelyRightPhrase, useAbsRight } from "../hooks/useAbsRight.js";
+import type { SessionPhase } from "../types.js";
 
 interface Props {
 	onExit: () => void;
-	phase?: "planning" | "execution" | "review" | "complete";
+	phase?: SessionPhase;
 	activity?: string;
 	quitState?: "normal" | "confirm";
 	onCtrlC?: () => void;

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,9 +1,10 @@
 import { Box, Text } from "ink";
 import type React from "react";
+import type { SessionPhase } from "../types.js";
 
 interface Props {
 	currentActivity: string;
-	phase?: "planning" | "execution" | "review" | "complete";
+	phase?: SessionPhase;
 }
 
 const PhasePill: React.FC<{ label: string; active?: boolean }> = ({

--- a/src/conversations/Architect.ts
+++ b/src/conversations/Architect.ts
@@ -3,6 +3,7 @@ import type {
 	AgentSession,
 	EmbeddedAgentProvider,
 } from "../providers/types.js";
+import { isAllToolsEnabled } from "../types/core.js";
 import type { Role } from "../types.js";
 import type { Logger } from "../utils/logger.js";
 
@@ -39,8 +40,9 @@ export class Architect extends EventEmitter {
 		let turnCount = 0;
 
 		try {
-			const toolsToPass =
-				this.allowedTools[0] === "all" ? undefined : this.allowedTools;
+			const toolsToPass = isAllToolsEnabled(this.allowedTools)
+				? undefined
+				: this.allowedTools;
 
 			// Create session with provider
 			// Note: Architect doesn't use MCP server, but we keep the parameter for consistency

--- a/src/conversations/Driver.ts
+++ b/src/conversations/Driver.ts
@@ -276,7 +276,12 @@ export class Driver extends EventEmitter {
 									});
 
 									// Store MCP tool results for driver communication
-									if (item.name?.startsWith("mcp__driver__")) {
+									if (!item.name) {
+										this.logger.logEvent("DRIVER_TOOL_MISSING_NAME", {
+											item: JSON.stringify(item),
+										});
+										console.warn("Driver: tool_use item missing name:", item);
+									} else if (item.name.startsWith("mcp__driver__")) {
 										this.toolResults.set(toolUseId, {
 											toolName: item.name,
 											input: item.input,

--- a/src/conversations/Driver.ts
+++ b/src/conversations/Driver.ts
@@ -4,7 +4,7 @@ import type {
 	EmbeddedAgentProvider,
 	StreamingAgentSession,
 } from "../providers/types.js";
-import { isAllToolsEnabled } from "../types/core.js";
+import { isAllToolsEnabled, isFileModificationTool } from "../types/core.js";
 import type { DriverCommand, Role } from "../types.js";
 import type { Logger } from "../utils/logger.js";
 import { DRIVER_TOOL_NAMES, driverMcpServer } from "../utils/mcpServers.js";
@@ -288,11 +288,7 @@ export class Driver extends EventEmitter {
 										});
 									}
 								}
-								if (
-									item.name === "Write" ||
-									item.name === "Edit" ||
-									item.name === "MultiEdit"
-								) {
+								if (item.name && isFileModificationTool(item.name)) {
 									const fileName = item.input?.file_path || "file";
 									this.logger.logEvent("DRIVER_FILE_MODIFIED", {
 										tool: item.name,

--- a/src/conversations/Driver.ts
+++ b/src/conversations/Driver.ts
@@ -4,6 +4,7 @@ import type {
 	EmbeddedAgentProvider,
 	StreamingAgentSession,
 } from "../providers/types.js";
+import { isAllToolsEnabled } from "../types/core.js";
 import type { DriverCommand, Role } from "../types.js";
 import type { Logger } from "../utils/logger.js";
 import { DRIVER_TOOL_NAMES, driverMcpServer } from "../utils/mcpServers.js";
@@ -196,8 +197,9 @@ export class Driver extends EventEmitter {
 		// Log session creation
 		try {
 			this.logger.logEvent("DRIVER_QUERY_INIT", {
-				allowedTools:
-					this.allowedTools[0] === "all" ? "all" : this.allowedTools,
+				allowedTools: isAllToolsEnabled(this.allowedTools)
+					? "all"
+					: this.allowedTools,
 				mcpServerUrl: this.mcpServerUrl || "embedded",
 				maxTurns: this.maxTurns,
 				hasSystemPrompt: !!this.systemPrompt,

--- a/src/conversations/Navigator.ts
+++ b/src/conversations/Navigator.ts
@@ -385,7 +385,14 @@ export class Navigator extends EventEmitter {
 								// Do not emit free-form navigator text; tools only
 								_fullText += `${item.text}\n`;
 							} else if (item.type === "tool_use") {
-								const tname = item.name || "";
+								if (!item.name) {
+									this.logger.logEvent("NAVIGATOR_TOOL_MISSING_NAME", {
+										item: JSON.stringify(item),
+									});
+									console.warn("Navigator: tool_use item missing name:", item);
+									continue;
+								}
+								const tname = item.name;
 								const isDecision = Navigator.isDecisionTool(tname);
 								let allowEmit = true;
 								if (this.inPermissionApproval) {

--- a/src/display.tsx
+++ b/src/display.tsx
@@ -5,7 +5,7 @@ import { useEffect } from "react";
 import ErrorBoundary from "./components/ErrorBoundary.js";
 import PairProgrammingApp from "./components/PairProgrammingApp.js";
 import { useMessages } from "./hooks/useMessages.js";
-import type { Message, Role } from "./types.js";
+import type { Message, Role, SessionPhase } from "./types.js";
 import type { AppConfig } from "./utils/config.js";
 import { formatSystemLine } from "./utils/systemLine.js";
 
@@ -27,10 +27,9 @@ export class InkDisplayManager {
 	private addMessage?: (message: Message) => void;
 	private updateActivity?: (activity: string) => void;
 	// Removed role switching/time remaining helpers
-	private setPhaseFn?: (
-		phase: "planning" | "execution" | "review" | "complete",
-	) => void;
+	private setPhaseFn?: (phase: SessionPhase) => void;
 	private setQuitStateFn?: (quitState: "normal" | "confirm") => void;
+	private currentPhase?: SessionPhase;
 	private firstCtrlCPressed = false;
 	private confirmExitTimer?: NodeJS.Timeout;
 	private syncTicker?: NodeJS.Timeout;
@@ -343,7 +342,7 @@ export class InkDisplayManager {
 		if (this.confirmExitTimer) clearTimeout(this.confirmExitTimer);
 	}
 
-	public setPhase(phase: "planning" | "execution" | "review" | "complete") {
+	public setPhase(phase: SessionPhase) {
 		if (this.setPhaseFn) {
 			this.setPhaseFn(phase);
 		}

--- a/src/display.tsx
+++ b/src/display.tsx
@@ -36,8 +36,6 @@ export class InkDisplayManager {
 	private syncTicker?: NodeJS.Timeout;
 	private config!: AppConfig;
 	private projectPath: string = process.cwd();
-	private currentPhase: "planning" | "execution" | "review" | "complete" =
-		"planning";
 
 	start(
 		projectPath: string,
@@ -309,9 +307,9 @@ export class InkDisplayManager {
 			? `✅ Task Complete!\n\n${summary}`
 			: "✅ Task Complete! Navigator has marked the implementation as finished.";
 
-		console.log("\n" + "=".repeat(60));
+		console.log(`\n${"=".repeat(60)}`);
 		console.log(message);
-		console.log("=".repeat(60) + "\n");
+		console.log(`${"=".repeat(60)}\n`);
 	}
 
 	cleanup() {

--- a/src/display.tsx
+++ b/src/display.tsx
@@ -303,13 +303,36 @@ export class InkDisplayManager {
 	}
 
 	showCompletionMessage(summary?: string) {
-		const message = summary
-			? `✅ Task Complete!\n\n${summary}`
-			: "✅ Task Complete! Navigator has marked the implementation as finished.";
+		// Add horizontal separator
+		const separatorMessage: Message = {
+			role: "system",
+			content: "─".repeat(80),
+			timestamp: new Date(),
+			sessionRole: "navigator",
+			symbol: "",
+		};
+		this.appendMessage(separatorMessage);
 
-		console.log(`\n${"=".repeat(60)}`);
-		console.log(message);
-		console.log(`${"=".repeat(60)}\n`);
+		// Add title with green checkmark
+		const titleMessage: Message = {
+			role: "system",
+			content: "✅ Task completed:",
+			timestamp: new Date(),
+			sessionRole: "navigator",
+			symbol: "",
+		};
+		this.appendMessage(titleMessage);
+
+		// Add completion summary
+		const completionText =
+			summary || "Navigator has marked the implementation as finished.";
+		const summaryMessage: Message = {
+			role: "assistant",
+			content: completionText,
+			timestamp: new Date(),
+			sessionRole: "navigator",
+		};
+		this.appendMessage(summaryMessage);
 	}
 
 	cleanup() {

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import type { Message, PairProgrammingState } from "../types.js";
+import type { Message, PairProgrammingState, SessionPhase } from "../types.js";
 
 export const useMessages = (projectPath: string, initialTask: string) => {
 	const [state, setState] = useState<PairProgrammingState>({
@@ -40,12 +40,9 @@ export const useMessages = (projectPath: string, initialTask: string) => {
 		setState((prev) => ({ ...prev, currentActivity: activity }));
 	}, []);
 
-	const setPhase = useCallback(
-		(phase: "planning" | "execution" | "review" | "complete") => {
-			setState((prev) => ({ ...prev, phase }));
-		},
-		[],
-	);
+	const setPhase = useCallback((phase: SessionPhase) => {
+		setState((prev) => ({ ...prev, phase }));
+	}, []);
 
 	const setQuitState = useCallback((quitState: "normal" | "confirm") => {
 		setState((prev) => ({ ...prev, quitState }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,12 +170,20 @@ class ClaudePairApp {
 		const drvUrl = this.mcp.urls.driver;
 		this.logger.logEvent("APP_MCP_URLS", { navUrl, drvUrl });
 
-		// Create architect provider
+		// Create providers for all agents
 		const architectProvider = agentProviderFactory.createProvider({
 			type: this.appConfig.architectProvider,
 		}) as EmbeddedAgentProvider;
 
-		// Create simple agents
+		const navigatorProvider = agentProviderFactory.createProvider({
+			type: this.appConfig.navigatorProvider,
+		}) as EmbeddedAgentProvider;
+
+		const driverProvider = agentProviderFactory.createProvider({
+			type: this.appConfig.driverProvider,
+		}) as EmbeddedAgentProvider;
+
+		// Create agents with providers
 		this.architect = new Architect(
 			PLANNING_NAVIGATOR_PROMPT,
 			["Read", "Grep", "Glob", "WebSearch", "WebFetch", "TodoWrite", "Bash"],
@@ -204,6 +212,7 @@ class ClaudePairApp {
 			this.appConfig.navigatorMaxTurns,
 			this.projectPath,
 			this.logger,
+			navigatorProvider,
 			navUrl,
 		);
 
@@ -272,6 +281,7 @@ class ClaudePairApp {
 			this.appConfig.driverMaxTurns,
 			this.projectPath,
 			this.logger,
+			driverProvider,
 			canUseTool,
 			drvUrl,
 		);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { InkDisplayManager } from "./display.js";
 import { type PairMcpServer, startPairMcpServer } from "./mcp/httpServer.js";
 import { agentProviderFactory } from "./providers/factory.js";
 import type { EmbeddedAgentProvider } from "./providers/types.js";
+import { isEmbeddedProvider } from "./providers/types.js";
 import {
 	NavigatorSessionError,
 	PermissionDeniedError,
@@ -139,7 +140,7 @@ class ClaudePairApp {
 		private task: string,
 	) {
 		const appConfig = loadConfig();
-		validateConfig(appConfig);
+		validateConfig(appConfig, agentProviderFactory.getAvailableProviders());
 		this.appConfig = appConfig;
 
 		this.config.projectPath = projectPath;
@@ -760,7 +761,7 @@ function showHelp(): void {
 async function main(): Promise<void> {
 	try {
 		const config = loadConfig();
-		validateConfig(config);
+		validateConfig(config, agentProviderFactory.getAvailableProviders());
 
 		const args = process.argv.slice(2);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,7 +220,7 @@ class ClaudePairApp {
 		const canUseTool = async (
 			toolName: string,
 			input: Record<string, unknown>,
-			options?: { suggestions?: Record<string, unknown> },
+			_options?: { suggestions?: Record<string, unknown> },
 		): Promise<
 			| {
 					behavior: "allow";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { Driver } from "./conversations/Driver.js";
 import { Navigator } from "./conversations/Navigator.js";
 import { InkDisplayManager } from "./display.js";
 import { type PairMcpServer, startPairMcpServer } from "./mcp/httpServer.js";
+import { agentProviderFactory } from "./providers/factory.js";
+import type { EmbeddedAgentProvider } from "./providers/types.js";
 import {
 	NavigatorSessionError,
 	PermissionDeniedError,
@@ -168,6 +170,11 @@ class ClaudePairApp {
 		const drvUrl = this.mcp.urls.driver;
 		this.logger.logEvent("APP_MCP_URLS", { navUrl, drvUrl });
 
+		// Create architect provider
+		const architectProvider = agentProviderFactory.createProvider({
+			type: this.appConfig.architectProvider,
+		}) as EmbeddedAgentProvider;
+
 		// Create simple agents
 		this.architect = new Architect(
 			PLANNING_NAVIGATOR_PROMPT,
@@ -175,6 +182,9 @@ class ClaudePairApp {
 			TURN_LIMITS.ARCHITECT,
 			this.projectPath,
 			this.logger,
+			architectProvider,
+			// Architect doesn't use MCP server, but we can pass empty string
+			"",
 		);
 
 		this.navigator = new Navigator(

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { type PairMcpServer, startPairMcpServer } from "./mcp/httpServer.js";
 import { agentProviderFactory } from "./providers/factory.js";
 import type { EmbeddedAgentProvider } from "./providers/types.js";
 import { isEmbeddedProvider } from "./providers/types.js";
+import { isFileModificationTool } from "./types/core.js";
 import {
 	NavigatorSessionError,
 	PermissionDeniedError,
@@ -230,8 +231,7 @@ class ClaudePairApp {
 			  }
 			| { behavior: "deny"; message: string }
 		> => {
-			const needsApproval =
-				toolName === "Write" || toolName === "Edit" || toolName === "MultiEdit";
+			const needsApproval = isFileModificationTool(toolName);
 
 			if (!needsApproval) {
 				return { behavior: "allow", updatedInput: input };

--- a/src/mcp/httpServer.ts
+++ b/src/mcp/httpServer.ts
@@ -63,7 +63,9 @@ export async function startPairMcpServer(
 				"mcp__driver__driverRequestGuidance",
 			],
 		});
-	} catch {}
+	} catch (error) {
+		console.warn("Failed to log MCP server initialization:", error);
+	}
 
 	const navTransports: TransportMap = new Map();
 	const drvTransports: TransportMap = new Map();
@@ -151,7 +153,9 @@ export async function startPairMcpServer(
 							role: "navigator",
 							sessionId: sid,
 						});
-					} catch {}
+					} catch (logError) {
+						console.warn("Failed to log navigator SSE post:", logError);
+					}
 					await t.handlePostMessage(req, res);
 					return;
 				}
@@ -225,7 +229,9 @@ export async function startPairMcpServer(
 							role: "driver",
 							sessionId: sid,
 						});
-					} catch {}
+					} catch (logError) {
+						console.warn("Failed to log driver SSE post:", logError);
+					}
 					await t.handlePostMessage(req, res);
 					return;
 				}
@@ -234,12 +240,16 @@ export async function startPairMcpServer(
 			} catch (err) {
 				try {
 					res.writeHead(500).end("error");
-				} catch {}
+				} catch (responseError) {
+					console.warn("Failed to send error response:", responseError);
+				}
 				try {
 					logger?.logEvent("MCP_HTTP_SERVER_ERROR", {
 						error: err instanceof Error ? err.message : String(err),
 					});
-				} catch {}
+				} catch (logError) {
+					console.warn("Failed to log MCP server error:", logError);
+				}
 			}
 		},
 	);

--- a/src/mcp/httpServer.ts
+++ b/src/mcp/httpServer.ts
@@ -276,7 +276,7 @@ export async function startPairMcpServer(
 					if (transport.close) {
 						transport.close();
 					}
-				} catch (e) {
+				} catch (_e) {
 					// Ignore close errors
 				}
 			}
@@ -287,7 +287,7 @@ export async function startPairMcpServer(
 					if (transport.close) {
 						transport.close();
 					}
-				} catch (e) {
+				} catch (_e) {
 					// Ignore close errors
 				}
 			}

--- a/src/providers/embedded/base.ts
+++ b/src/providers/embedded/base.ts
@@ -9,6 +9,8 @@ import type {
 	EmbeddedAgentProvider,
 	ProviderConfig,
 	SessionOptions,
+	StreamingAgentSession,
+	StreamingSessionOptions,
 } from "../types.js";
 
 /**
@@ -25,6 +27,14 @@ export abstract class BaseEmbeddedProvider implements EmbeddedAgentProvider {
 	 * Must be implemented by concrete providers
 	 */
 	abstract createSession(options: SessionOptions): AgentSession;
+
+	/**
+	 * Create a streaming session for Driver/Navigator agents
+	 * Must be implemented by concrete providers
+	 */
+	abstract createStreamingSession(
+		options: StreamingSessionOptions,
+	): StreamingAgentSession;
 
 	/**
 	 * Optional initialization

--- a/src/providers/embedded/base.ts
+++ b/src/providers/embedded/base.ts
@@ -1,0 +1,42 @@
+/**
+ * Base class for embedded agent providers
+ *
+ * Embedded providers run in-process and connect to MCP servers via HTTP/SSE
+ */
+
+import type {
+	AgentSession,
+	EmbeddedAgentProvider,
+	ProviderConfig,
+	SessionOptions,
+} from "../types.js";
+
+/**
+ * Abstract base class for embedded agent providers
+ */
+export abstract class BaseEmbeddedProvider implements EmbeddedAgentProvider {
+	readonly type = "embedded" as const;
+	abstract readonly name: string;
+
+	constructor(protected config: ProviderConfig) {}
+
+	/**
+	 * Create a new agent session
+	 * Must be implemented by concrete providers
+	 */
+	abstract createSession(options: SessionOptions): AgentSession;
+
+	/**
+	 * Optional initialization
+	 */
+	async initialize(): Promise<void> {
+		// Override in subclasses if needed
+	}
+
+	/**
+	 * Optional cleanup
+	 */
+	async cleanup(): Promise<void> {
+		// Override in subclasses if needed
+	}
+}

--- a/src/providers/embedded/claudeCode.ts
+++ b/src/providers/embedded/claudeCode.ts
@@ -12,8 +12,11 @@ import type {
 	AgentInputStream,
 	AgentMessage,
 	AgentSession,
+	CanUseToolFunction,
+	McpServerConfig,
 	SessionOptions,
 	StreamingAgentSession,
+	StreamingCanUseToolFunction,
 	StreamingSessionOptions,
 } from "../types.js";
 import { BaseEmbeddedProvider } from "./base.js";
@@ -31,6 +34,7 @@ class ClaudeCodeSession implements AgentSession {
 		this.inputStream = new AsyncUserMessageStream();
 
 		// Configure MCP servers for communication (only for Navigator/Driver)
+		// Note: Using 'as any' due to Claude Code SDK internal type differences
 		const mcpServers = options.role
 			? {
 					[options.role]: {
@@ -50,6 +54,7 @@ class ClaudeCodeSession implements AgentSession {
 			permissionMode: options.permissionMode || "default",
 			maxTurns: options.maxTurns,
 			includePartialMessages: options.includePartialMessages ?? true,
+			// Note: Claude Code SDK has different type signature than our interface
 			canUseTool: options.canUseTool as any,
 		};
 
@@ -136,6 +141,7 @@ class ClaudeCodeStreamingSession implements StreamingAgentSession {
 			: undefined;
 
 		// Configure MCP servers (embedded vs HTTP/SSE)
+		// Note: Using 'as any' for HTTP/SSE config due to Claude Code SDK internal type differences
 		const mcpServers = options.mcpServerUrl
 			? { [options.mcpRole]: { type: "sse", url: options.mcpServerUrl } as any }
 			: { [options.mcpRole]: options.embeddedMcpServer };
@@ -152,6 +158,7 @@ class ClaudeCodeStreamingSession implements StreamingAgentSession {
 				permissionMode: "default",
 				maxTurns: options.maxTurns,
 				includePartialMessages: options.includePartialMessages ?? true,
+				// Note: Claude Code SDK has different type signature than our interface
 				canUseTool: options.canUseTool as any,
 			},
 		}) as AsyncGenerator<any, void>;

--- a/src/providers/embedded/claudeCode.ts
+++ b/src/providers/embedded/claudeCode.ts
@@ -74,15 +74,26 @@ class ClaudeCodeSession implements AgentSession {
 	 * AsyncIterable implementation
 	 */
 	async *[Symbol.asyncIterator](): AsyncIterator<AgentMessage> {
-		for await (const message of this.iterator) {
-			// Capture session ID
-			if (message.session_id && !this.sessionId) {
-				this.sessionId = message.session_id;
-			}
+		try {
+			for await (const message of this.iterator) {
+				// Capture session ID
+				if (message.session_id && !this.sessionId) {
+					this.sessionId = message.session_id;
+				}
 
-			// Pass through messages with minimal transformation
-			// The agent classes expect Claude Code message format
-			yield message as AgentMessage;
+				// Pass through messages with minimal transformation
+				// The agent classes expect Claude Code message format
+				yield message as AgentMessage;
+			}
+		} catch (error) {
+			// Add context to session errors
+			const contextualError = new Error(
+				`Claude Code session failed (session_id: ${this.sessionId || "none"}): ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			contextualError.cause = error;
+			throw contextualError;
 		}
 	}
 
@@ -150,14 +161,25 @@ class ClaudeCodeStreamingSession implements StreamingAgentSession {
 	 * AsyncIterable implementation
 	 */
 	async *[Symbol.asyncIterator](): AsyncIterator<AgentMessage> {
-		for await (const message of this.iterator) {
-			// Capture session ID
-			if (message.session_id && !this.sessionId) {
-				this.sessionId = message.session_id;
-			}
+		try {
+			for await (const message of this.iterator) {
+				// Capture session ID
+				if (message.session_id && !this.sessionId) {
+					this.sessionId = message.session_id;
+				}
 
-			// Pass through messages with minimal transformation
-			yield message as AgentMessage;
+				// Pass through messages with minimal transformation
+				yield message as AgentMessage;
+			}
+		} catch (error) {
+			// Add context to streaming session errors
+			const contextualError = new Error(
+				`Claude Code streaming session failed (session_id: ${this.sessionId || "none"}): ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			contextualError.cause = error;
+			throw contextualError;
 		}
 	}
 

--- a/src/providers/embedded/claudeCode.ts
+++ b/src/providers/embedded/claudeCode.ts
@@ -29,13 +29,15 @@ class ClaudeCodeSession implements AgentSession {
 	constructor(options: SessionOptions) {
 		this.inputStream = new AsyncUserMessageStream();
 
-		// Configure MCP servers for communication
-		const mcpServers = {
-			[options.mcpServerUrl.includes("/navigator") ? "navigator" : "driver"]: {
-				type: "sse",
-				url: options.mcpServerUrl,
-			} as any,
-		};
+		// Configure MCP servers for communication (only for Navigator/Driver)
+		const mcpServers = options.role
+			? {
+					[options.role]: {
+						type: "sse",
+						url: options.mcpServerUrl,
+					} as any,
+				}
+			: {};
 
 		// Convert options to Claude Code SDK format
 		const queryOptions = {

--- a/src/providers/embedded/claudeCode.ts
+++ b/src/providers/embedded/claudeCode.ts
@@ -1,0 +1,115 @@
+/**
+ * Claude Code provider implementation
+ *
+ * Uses the Claude Code SDK to create embedded agent sessions that connect
+ * to MCP servers via HTTP/SSE
+ */
+
+import { query } from "@anthropic-ai/claude-code";
+import { AsyncUserMessageStream } from "../../utils/streamInput.js";
+import type {
+	AgentMessage,
+	AgentSession,
+	ProviderConfig,
+	SessionOptions,
+} from "../types.js";
+import { BaseEmbeddedProvider } from "./base.js";
+
+/**
+ * Session implementation for Claude Code
+ */
+class ClaudeCodeSession implements AgentSession {
+	sessionId: string | null = null;
+	private iterator: AsyncGenerator<any, void>;
+	private inputStream: AsyncUserMessageStream;
+	private ended = false;
+
+	constructor(options: SessionOptions) {
+		this.inputStream = new AsyncUserMessageStream();
+
+		// Configure MCP servers for communication
+		const mcpServers = {
+			[options.mcpServerUrl.includes("/navigator") ? "navigator" : "driver"]: {
+				type: "sse",
+				url: options.mcpServerUrl,
+			} as any,
+		};
+
+		// Convert options to Claude Code SDK format
+		const queryOptions = {
+			cwd: options.projectPath,
+			appendSystemPrompt: options.systemPrompt,
+			allowedTools: options.allowedTools,
+			disallowedTools: options.disallowedTools,
+			mcpServers,
+			permissionMode: options.permissionMode || "default",
+			maxTurns: options.maxTurns,
+			includePartialMessages: options.includePartialMessages ?? true,
+			canUseTool: options.canUseTool as any,
+		};
+
+		// Create the query session
+		this.iterator = query({
+			prompt: this.inputStream as any,
+			options: queryOptions,
+		}) as AsyncGenerator<any, void>;
+	}
+
+	/**
+	 * Send a message to the agent
+	 */
+	sendMessage(message: string): void {
+		if (this.ended) {
+			throw new Error("Cannot send message to ended session");
+		}
+		this.inputStream.pushText(message);
+	}
+
+	/**
+	 * AsyncIterable implementation
+	 */
+	async *[Symbol.asyncIterator](): AsyncIterator<AgentMessage> {
+		for await (const message of this.iterator) {
+			// Capture session ID
+			if (message.session_id && !this.sessionId) {
+				this.sessionId = message.session_id;
+			}
+
+			// Pass through messages with minimal transformation
+			// The agent classes expect Claude Code message format
+			yield message as AgentMessage;
+		}
+	}
+
+	/**
+	 * Interrupt the session
+	 */
+	async interrupt(): Promise<void> {
+		// Use Claude SDK's interrupt if available
+		if ((this.iterator as any).interrupt) {
+			await (this.iterator as any).interrupt();
+		}
+	}
+
+	/**
+	 * End the session
+	 */
+	end(): void {
+		this.ended = true;
+		this.inputStream.end();
+	}
+}
+
+/**
+ * Claude Code provider implementation
+ */
+export class ClaudeCodeProvider extends BaseEmbeddedProvider {
+	readonly name = "claude-code";
+
+	/**
+	 * Create a new Claude Code session
+	 */
+	createSession(options: SessionOptions): AgentSession {
+		return new ClaudeCodeSession(options);
+	}
+}

--- a/src/providers/embedded/claudeCode.ts
+++ b/src/providers/embedded/claudeCode.ts
@@ -11,7 +11,6 @@ import type {
 	AgentInputStream,
 	AgentMessage,
 	AgentSession,
-	ProviderConfig,
 	SessionOptions,
 	StreamingAgentSession,
 	StreamingSessionOptions,

--- a/src/providers/embedded/claudeCode.ts
+++ b/src/providers/embedded/claudeCode.ts
@@ -6,6 +6,7 @@
  */
 
 import { query } from "@anthropic-ai/claude-code";
+import { isAllToolsEnabled } from "../../types/core.js";
 import { AsyncUserMessageStream } from "../../utils/streamInput.js";
 import type {
 	AgentInputStream,
@@ -116,8 +117,9 @@ class ClaudeCodeStreamingSession implements StreamingAgentSession {
 		this.inputStream = new AsyncUserMessageStream();
 
 		// Combine standard tools with MCP tools (extracted from Driver/Navigator logic)
-		const baseTools =
-			options.allowedTools[0] === "all" ? undefined : options.allowedTools;
+		const baseTools = isAllToolsEnabled(options.allowedTools)
+			? undefined
+			: options.allowedTools;
 		const toolsToPass: string[] | undefined = baseTools
 			? [...baseTools, ...options.additionalMcpTools]
 			: undefined;

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,0 +1,64 @@
+/**
+ * Factory for creating and managing agent providers
+ */
+
+import { ClaudeCodeProvider } from "./embedded/claudeCode.js";
+import type {
+	AgentProvider,
+	AgentProviderFactory,
+	ProviderConfig,
+} from "./types.js";
+
+/**
+ * Default factory implementation
+ */
+export class DefaultAgentProviderFactory implements AgentProviderFactory {
+	private providers = new Map<
+		string,
+		new (
+			config: ProviderConfig,
+		) => AgentProvider
+	>();
+
+	constructor() {
+		// Register default providers
+		this.registerProvider("claude-code", ClaudeCodeProvider);
+	}
+
+	/**
+	 * Create a provider instance based on configuration
+	 */
+	createProvider(config: ProviderConfig): AgentProvider {
+		const ProviderClass = this.providers.get(config.type);
+
+		if (!ProviderClass) {
+			throw new Error(
+				`Unknown provider type: ${config.type}. Available providers: ${this.getAvailableProviders().join(", ")}`,
+			);
+		}
+
+		return new ProviderClass(config);
+	}
+
+	/**
+	 * Register a new provider type
+	 */
+	registerProvider(
+		type: string,
+		providerClass: new (config: ProviderConfig) => AgentProvider,
+	): void {
+		this.providers.set(type, providerClass);
+	}
+
+	/**
+	 * Get list of available provider types
+	 */
+	getAvailableProviders(): string[] {
+		return Array.from(this.providers.keys());
+	}
+}
+
+/**
+ * Global factory instance
+ */
+export const agentProviderFactory = new DefaultAgentProviderFactory();

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Provider module exports
+ */
+
+export { BaseEmbeddedProvider } from "./embedded/base.js";
+export { ClaudeCodeProvider } from "./embedded/claudeCode.js";
+export {
+	agentProviderFactory,
+	DefaultAgentProviderFactory,
+} from "./factory.js";
+export * from "./types.js";

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,178 @@
+/**
+ * Provider abstraction layer for coding agents
+ *
+ * This module defines interfaces for different coding agent implementations
+ * (Claude Code, Codex, OpenCode, etc.) while preserving MCP as the universal
+ * communication protocol between agents.
+ */
+
+import type { EventEmitter } from "node:events";
+import type { Role } from "../types.js";
+import type { Logger } from "../utils/logger.js";
+
+/**
+ * Agent message types that providers must handle
+ */
+export interface AgentMessage {
+	type: "assistant" | "user" | "system" | "result";
+	session_id?: string;
+	message?: {
+		content:
+			| Array<{
+					type: "text" | "tool_use" | "tool_result";
+					text?: string;
+					name?: string;
+					input?: Record<string, unknown>;
+					id?: string;
+					tool_use_id?: string;
+					content?: unknown;
+					is_error?: boolean;
+			  }>
+			| string;
+	};
+	subtype?: string; // For system messages like "turn_limit_reached"
+}
+
+/**
+ * Provider configuration for each agent role
+ */
+export interface ProviderConfig {
+	type: "claude-code" | "codex" | "opencode" | string;
+	apiKey?: string;
+	model?: string;
+	baseUrl?: string;
+	options?: Record<string, unknown>;
+}
+
+/**
+ * Base interface for all agent providers
+ */
+export interface AgentProvider {
+	/**
+	 * Provider name (e.g., "claude-code", "codex", "opencode")
+	 */
+	readonly name: string;
+
+	/**
+	 * Provider type: embedded (in-process) or external (separate service)
+	 */
+	readonly type: "embedded" | "external";
+
+	/**
+	 * Initialize the provider
+	 */
+	initialize?(): Promise<void>;
+
+	/**
+	 * Clean up resources
+	 */
+	cleanup?(): Promise<void>;
+}
+
+/**
+ * Session interface for embedded agent conversations
+ */
+export interface AgentSession extends AsyncIterable<AgentMessage> {
+	/**
+	 * Session identifier
+	 */
+	sessionId: string | null;
+
+	/**
+	 * Send a message to the agent
+	 */
+	sendMessage(message: string): void;
+
+	/**
+	 * Interrupt the session
+	 */
+	interrupt?(): Promise<void>;
+
+	/**
+	 * End the session
+	 */
+	end(): void;
+}
+
+/**
+ * Options for creating an agent session
+ */
+export interface SessionOptions {
+	systemPrompt: string;
+	allowedTools: string[] | undefined; // undefined means all tools
+	maxTurns: number;
+	projectPath: string;
+	mcpServerUrl: string;
+	canUseTool?: (
+		toolName: string,
+		input: Record<string, unknown>,
+		options?: { signal?: AbortSignal; suggestions?: Record<string, unknown> },
+	) => Promise<
+		| {
+				behavior: "allow";
+				updatedInput: Record<string, unknown>;
+				updatedPermissions?: Record<string, unknown>;
+		  }
+		| { behavior: "deny"; message: string }
+	>;
+	permissionMode?: "default" | "plan";
+	includePartialMessages?: boolean;
+	disallowedTools?: string[];
+}
+
+/**
+ * Embedded provider interface for in-process agents (like Claude Code)
+ */
+export interface EmbeddedAgentProvider extends AgentProvider {
+	readonly type: "embedded";
+
+	/**
+	 * Create a new session with the agent
+	 */
+	createSession(options: SessionOptions): AgentSession;
+}
+
+/**
+ * External provider interface for out-of-process agents (future Codex, OpenCode, etc.)
+ */
+export interface ExternalAgentProvider extends AgentProvider {
+	readonly type: "external";
+
+	/**
+	 * Get the connection details for the external agent
+	 * The external agent will connect directly to the MCP server endpoints
+	 */
+	getConnectionInfo(): {
+		serviceUrl: string;
+		apiKey?: string;
+		headers?: Record<string, string>;
+	};
+
+	/**
+	 * Health check for the external service
+	 */
+	healthCheck(): Promise<boolean>;
+}
+
+/**
+ * Factory for creating agent providers
+ */
+export interface AgentProviderFactory {
+	/**
+	 * Create a provider based on configuration
+	 */
+	createProvider(config: ProviderConfig): AgentProvider;
+
+	/**
+	 * Register a new provider type
+	 */
+	registerProvider(
+		type: string,
+		providerClass: new (config: ProviderConfig) => AgentProvider,
+	): void;
+
+	/**
+	 * Get list of available provider types
+	 */
+	getAvailableProviders(): string[];
+}

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -214,6 +214,28 @@ export interface ExternalAgentProvider extends AgentProvider {
 }
 
 /**
+ * MCP Server configuration for Claude Code SDK
+ */
+export interface McpServerConfig {
+	type: "sse" | "stdio";
+	url?: string;
+	command?: string;
+	args?: string[];
+}
+
+/**
+ * Type alias for canUseTool function from SessionOptions
+ */
+export type CanUseToolFunction = NonNullable<SessionOptions["canUseTool"]>;
+
+/**
+ * Type alias for canUseTool function from StreamingSessionOptions
+ */
+export type StreamingCanUseToolFunction = NonNullable<
+	StreamingSessionOptions["canUseTool"]
+>;
+
+/**
  * Type guard to check if a provider is embedded
  */
 export function isEmbeddedProvider(

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -127,6 +127,7 @@ export interface SessionOptions {
 	maxTurns: number;
 	projectPath: string;
 	mcpServerUrl: string;
+	role?: "navigator" | "driver"; // Explicit role instead of URL parsing (optional for Architect)
 	canUseTool?: (
 		toolName: string,
 		input: Record<string, unknown>,

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -6,10 +6,6 @@
  * communication protocol between agents.
  */
 
-import type { EventEmitter } from "node:events";
-import type { Role } from "../types.js";
-import type { Logger } from "../utils/logger.js";
-
 /**
  * Agent message types that providers must handle
  */

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -214,6 +214,15 @@ export interface ExternalAgentProvider extends AgentProvider {
 }
 
 /**
+ * Type guard to check if a provider is embedded
+ */
+export function isEmbeddedProvider(
+	provider: AgentProvider,
+): provider is EmbeddedAgentProvider {
+	return provider.type === "embedded";
+}
+
+/**
  * Factory for creating agent providers
  */
 export interface AgentProviderFactory {

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -6,6 +6,18 @@ export type Role = "navigator" | "driver" | "architect";
 
 export type SessionPhase = "planning" | "execution" | "review" | "complete";
 
+/**
+ * Constant representing "allow all tools" in allowedTools arrays
+ */
+export const ALL_TOOLS_MARKER = "all" as const;
+
+/**
+ * Helper function to check if allowedTools array represents "all tools"
+ */
+export function isAllToolsEnabled(allowedTools: string[]): boolean {
+	return allowedTools.length > 0 && allowedTools[0] === ALL_TOOLS_MARKER;
+}
+
 export interface Message {
 	role: "user" | "assistant" | "system";
 	content: string;

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -13,9 +13,10 @@ export const ALL_TOOLS_MARKER = "all" as const;
 
 /**
  * Helper function to check if allowedTools array represents "all tools"
+ * Empty array or array starting with "all" means all tools enabled
  */
 export function isAllToolsEnabled(allowedTools: string[]): boolean {
-	return allowedTools.length > 0 && allowedTools[0] === ALL_TOOLS_MARKER;
+	return allowedTools.length === 0 || allowedTools[0] === ALL_TOOLS_MARKER;
 }
 
 /**

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -4,6 +4,8 @@
 
 export type Role = "navigator" | "driver" | "architect";
 
+export type SessionPhase = "planning" | "execution" | "review" | "complete";
+
 export interface Message {
 	role: "user" | "assistant" | "system";
 	content: string;
@@ -36,7 +38,7 @@ export interface PairProgrammingState {
 	navigatorMessages: Message[];
 	driverMessages: Message[];
 	currentActivity: string;
-	phase?: "planning" | "execution" | "review" | "complete";
+	phase?: SessionPhase;
 	quitState?: "normal" | "confirm";
 }
 

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -18,6 +18,20 @@ export function isAllToolsEnabled(allowedTools: string[]): boolean {
 	return allowedTools.length > 0 && allowedTools[0] === ALL_TOOLS_MARKER;
 }
 
+/**
+ * File modification tools that require special handling
+ */
+export const FILE_MODIFICATION_TOOLS = ["Write", "Edit", "MultiEdit"] as const;
+
+/**
+ * Type guard to check if a tool is a file modification tool
+ */
+export function isFileModificationTool(
+	toolName: string,
+): toolName is (typeof FILE_MODIFICATION_TOOLS)[number] {
+	return FILE_MODIFICATION_TOOLS.includes(toolName as any);
+}
+
 export interface Message {
 	role: "user" | "assistant" | "system";
 	content: string;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -87,7 +87,10 @@ export function loadConfig(): AppConfig {
 /**
  * Validate configuration values
  */
-export function validateConfig(config: AppConfig): void {
+export function validateConfig(
+	config: AppConfig,
+	availableProviders?: string[],
+): void {
 	if (config.navigatorMaxTurns < 10 || config.navigatorMaxTurns > 100) {
 		throw new Error("Navigator max turns must be between 10 and 100");
 	}
@@ -114,5 +117,22 @@ export function validateConfig(config: AppConfig): void {
 		config.sessionHardLimitMs > 8 * 60 * 60 * 1000
 	) {
 		throw new Error("Session hard limit must be between 1 minute and 8 hours");
+	}
+
+	// Validate provider types if available providers list is provided
+	if (availableProviders) {
+		const providers = [
+			{ name: "architect", type: config.architectProvider },
+			{ name: "navigator", type: config.navigatorProvider },
+			{ name: "driver", type: config.driverProvider },
+		];
+
+		for (const provider of providers) {
+			if (!availableProviders.includes(provider.type)) {
+				throw new Error(
+					`Unknown ${provider.name} provider type: "${provider.type}". Available providers: ${availableProviders.join(", ")}`,
+				);
+			}
+		}
 	}
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -23,6 +23,9 @@ export interface AppConfig {
 
 	/** Enable sync status updates in footer (default: true) */
 	enableSyncStatus: boolean;
+
+	/** Provider type for architect agent (default: "claude-code") */
+	architectProvider: string;
 }
 
 export const DEFAULT_CONFIG: AppConfig = {
@@ -33,6 +36,7 @@ export const DEFAULT_CONFIG: AppConfig = {
 	model: undefined, // Use CLI default
 	sessionHardLimitMs: 30 * 60 * 1000, // 30 minutes
 	enableSyncStatus: true, // Enable by default
+	architectProvider: "claude-code",
 };
 
 /**
@@ -59,6 +63,9 @@ export function loadConfig(): AppConfig {
 			60 *
 			1000,
 		enableSyncStatus: process.env.CLAUDE_PAIR_DISABLE_SYNC_STATUS !== "true",
+		architectProvider:
+			process.env.CLAUDE_PAIR_ARCHITECT_PROVIDER ||
+			DEFAULT_CONFIG.architectProvider,
 	};
 
 	return config;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -26,6 +26,12 @@ export interface AppConfig {
 
 	/** Provider type for architect agent (default: "claude-code") */
 	architectProvider: string;
+
+	/** Provider type for navigator agent (default: "claude-code") */
+	navigatorProvider: string;
+
+	/** Provider type for driver agent (default: "claude-code") */
+	driverProvider: string;
 }
 
 export const DEFAULT_CONFIG: AppConfig = {
@@ -37,6 +43,8 @@ export const DEFAULT_CONFIG: AppConfig = {
 	sessionHardLimitMs: 30 * 60 * 1000, // 30 minutes
 	enableSyncStatus: true, // Enable by default
 	architectProvider: "claude-code",
+	navigatorProvider: "claude-code",
+	driverProvider: "claude-code",
 };
 
 /**
@@ -66,6 +74,11 @@ export function loadConfig(): AppConfig {
 		architectProvider:
 			process.env.CLAUDE_PAIR_ARCHITECT_PROVIDER ||
 			DEFAULT_CONFIG.architectProvider,
+		navigatorProvider:
+			process.env.CLAUDE_PAIR_NAVIGATOR_PROVIDER ||
+			DEFAULT_CONFIG.navigatorProvider,
+		driverProvider:
+			process.env.CLAUDE_PAIR_DRIVER_PROVIDER || DEFAULT_CONFIG.driverProvider,
 	};
 
 	return config;

--- a/test/integration/basicFlow.integration.test.ts
+++ b/test/integration/basicFlow.integration.test.ts
@@ -1,21 +1,43 @@
 /**
- * Integration tests using real Claude Code SDK
- * These tests use actual AI responses - use sparingly and with controlled prompts
+ * Integration tests for Navigator with real MCP server
+ * These tests verify Navigator behavior with proper MCP infrastructure
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { Navigator } from "../../src/conversations/Navigator.js";
 import { Logger } from "../../src/utils/logger.js";
 import type { PermissionRequest } from "../../src/types/permission.js";
 import { driverRequestReview } from "../../src/utils/mcpTools.js";
+import { startPairMcpServer, type PairMcpServer } from "../../src/mcp/httpServer.js";
 
 
 // Only run integration tests if enabled
 const integrationTestsEnabled = process.env.RUN_INTEGRATION_TESTS;
 
-describe.skipIf(!integrationTestsEnabled)("Integration Tests", () => {
+describe.skipIf(!integrationTestsEnabled)("Navigator Integration Tests", () => {
   let navigator: Navigator;
   let mockLogger: Logger;
+  let mcpServer: PairMcpServer;
+
+  beforeAll(async () => {
+    // Start MCP server for tests
+    mcpServer = await startPairMcpServer();
+    console.log('Test MCP Server started on port:', mcpServer.port);
+  });
+
+  afterEach(async () => {
+    // Stop navigator after each test to close SSE connections
+    if (navigator) {
+      await navigator.stop();
+    }
+  });
+
+  afterAll(async () => {
+    // Close the MCP server
+    if (mcpServer) {
+      await mcpServer.close();
+    }
+  });
 
   beforeEach(() => {
     mockLogger = {
@@ -24,12 +46,14 @@ describe.skipIf(!integrationTestsEnabled)("Integration Tests", () => {
       close: vi.fn(),
     } as any;
 
+    // Create Navigator with MCP server URL
     navigator = new Navigator(
       "You are a navigator in a pair programming session. Respond only with MCP tool calls.",
       ["Read", "Grep", "Glob"],
       5, // Low turn limit for integration tests
       process.cwd(),
       mockLogger,
+      mcpServer.urls.navigator, // Provide the actual MCP server URL
     );
   });
 
@@ -57,11 +81,21 @@ describe.skipIf(!integrationTestsEnabled)("Integration Tests", () => {
   }, 20000); // 20 second timeout
 
   it("should handle a review request triggered by driver tool call", async () => {
+    // Initialize navigator with a simple task and plan
+    await navigator.initialize(
+      "Add a hello world function",
+      "1. Create a hello world function\n2. Test it works"
+    );
+
     // Call the actual driverRequestReview tool handler to simulate real flow
-    const toolResult = await driverRequestReview.handler({ context: "I added a hello world function" });
+    const toolResult = await driverRequestReview.handler(
+      { context: "I added a hello world function" },
+      {} as any
+    );
 
     // Extract the message that would be sent to Navigator
-    const reviewMessage = toolResult.content[0]?.text || "Driver requesting review";
+    const contentItem = toolResult.content[0];
+    const reviewMessage = (contentItem && 'text' in contentItem && typeof contentItem.text === 'string' ? contentItem.text : undefined) || "Driver requesting review";
 
     const commands = await navigator.processDriverMessage(reviewMessage);
 
@@ -70,7 +104,6 @@ describe.skipIf(!integrationTestsEnabled)("Integration Tests", () => {
     if (commands && commands.length > 0) {
       expect(commands[0].type).toMatch(/^(code_review|complete)$/);
     }
-
   }, 20000);
 });
 

--- a/test/integration/basicFlow.integration.test.ts
+++ b/test/integration/basicFlow.integration.test.ts
@@ -11,6 +11,14 @@ import { driverRequestReview } from "../../src/utils/mcpTools.js";
 import { startPairMcpServer, type PairMcpServer } from "../../src/mcp/httpServer.js";
 import { ClaudeCodeProvider } from "../../src/providers/embedded/claudeCode.js";
 
+/**
+ * Helper function to extract text content from a tool result content item
+ */
+function extractTextContent(contentItem: any): string | undefined {
+  return contentItem && 'text' in contentItem && typeof contentItem.text === 'string'
+    ? contentItem.text
+    : undefined;
+}
 
 // Only run integration tests if enabled
 const integrationTestsEnabled = process.env.RUN_INTEGRATION_TESTS;
@@ -100,7 +108,7 @@ describe.skipIf(!integrationTestsEnabled)("Navigator Integration Tests", () => {
 
     // Extract the message that would be sent to Navigator
     const contentItem = toolResult.content[0];
-    const reviewMessage = (contentItem && 'text' in contentItem && typeof contentItem.text === 'string' ? contentItem.text : undefined) || "Driver requesting review";
+    const reviewMessage = extractTextContent(contentItem) || "Driver requesting review";
 
     const commands = await navigator.processDriverMessage(reviewMessage);
 

--- a/test/integration/basicFlow.integration.test.ts
+++ b/test/integration/basicFlow.integration.test.ts
@@ -9,6 +9,7 @@ import { Logger } from "../../src/utils/logger.js";
 import type { PermissionRequest } from "../../src/types/permission.js";
 import { driverRequestReview } from "../../src/utils/mcpTools.js";
 import { startPairMcpServer, type PairMcpServer } from "../../src/mcp/httpServer.js";
+import { ClaudeCodeProvider } from "../../src/providers/embedded/claudeCode.js";
 
 
 // Only run integration tests if enabled
@@ -46,13 +47,17 @@ describe.skipIf(!integrationTestsEnabled)("Navigator Integration Tests", () => {
       close: vi.fn(),
     } as any;
 
-    // Create Navigator with MCP server URL
+    // Create real Claude Code provider for integration tests
+    const provider = new ClaudeCodeProvider({ type: "claude-code" });
+
+    // Create Navigator with provider and MCP server URL
     navigator = new Navigator(
       "You are a navigator in a pair programming session. Respond only with MCP tool calls.",
       ["Read", "Grep", "Glob"],
       5, // Low turn limit for integration tests
       process.cwd(),
       mockLogger,
+      provider,
       mcpServer.urls.navigator, // Provide the actual MCP server URL
     );
   });

--- a/test/integration/providers/claudeCode.integration.test.ts
+++ b/test/integration/providers/claudeCode.integration.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Integration tests for ClaudeCodeProvider with real MCP server
+ * These tests verify the provider works with actual HTTP/SSE communication
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { ClaudeCodeProvider } from '../../../src/providers/embedded/claudeCode.js';
+import { startPairMcpServer, type PairMcpServer } from '../../../src/mcp/httpServer.js';
+import type { SessionOptions } from '../../../src/providers/types.js';
+
+// Only run integration tests if enabled
+const integrationTestsEnabled = false; //process.env.RUN_INTEGRATION_TESTS;
+
+describe.skipIf(!integrationTestsEnabled)("ClaudeCodeProvider Integration", () => {
+  let mcpServer: PairMcpServer;
+  let provider: ClaudeCodeProvider;
+
+  beforeAll(async () => {
+    // Start real MCP server
+    mcpServer = await startPairMcpServer();
+    console.log('MCP Server started on port:', mcpServer.port);
+  });
+
+  afterAll(async () => {
+    if (mcpServer) {
+      await mcpServer.close();
+      console.log('MCP Server closed');
+    }
+  });
+
+  beforeEach(() => {
+    provider = new ClaudeCodeProvider({ type: 'claude-code' });
+  });
+
+  it('should connect to navigator MCP endpoint', async () => {
+    const options: SessionOptions = {
+      systemPrompt: "You are a test navigator. Respond only with MCP tool calls.",
+      allowedTools: ["Read", "Grep"],
+      maxTurns: 2,
+      projectPath: process.cwd(),
+      mcpServerUrl: mcpServer.urls.navigator,
+      permissionMode: "default",
+    };
+
+    const session = provider.createSession(options);
+    expect(session).toBeDefined();
+
+    // Send a message that should trigger MCP tools
+    session.sendMessage("Please approve this test request using mcp__navigator__navigatorApprove tool with comment='Test approval'");
+
+    // Wait for response (with timeout)
+    const timeout = new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('Timeout')), 5000)
+    );
+
+    try {
+      const messagePromise = (async () => {
+        for await (const message of session) {
+          console.log('Received message type:', message.type);
+          if (message.type === 'assistant' || message.type === 'result') {
+            return message;
+          }
+        }
+      })();
+
+      const result = await Promise.race([messagePromise, timeout]);
+      expect(result).toBeDefined();
+    } catch (error) {
+      // This might timeout without API keys, which is expected
+      console.log('Session iteration completed or timed out (expected without API keys)');
+    } finally {
+      session.end();
+    }
+  }, 10000);
+
+  it('should connect to driver MCP endpoint', async () => {
+    const options: SessionOptions = {
+      systemPrompt: "You are a test driver. Use MCP tools to communicate.",
+      allowedTools: ["Read", "Write"],
+      maxTurns: 2,
+      projectPath: process.cwd(),
+      mcpServerUrl: mcpServer.urls.driver,
+      permissionMode: "default",
+    };
+
+    const session = provider.createSession(options);
+    expect(session).toBeDefined();
+
+    // Send a message that might trigger driver tools
+    session.sendMessage("Request a review using mcp__driver__driverRequestReview tool");
+
+    // Wait briefly to ensure no immediate errors
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Session should still be valid
+    expect(() => session.sendMessage("Another message")).not.toThrow();
+
+    session.end();
+  }, 10000);
+
+  it('should handle session lifecycle correctly', async () => {
+    const session = provider.createSession({
+      systemPrompt: "Test system prompt",
+      allowedTools: undefined, // All tools
+      maxTurns: 1,
+      projectPath: process.cwd(),
+      mcpServerUrl: mcpServer.urls.navigator,
+    });
+
+    // Session starts with no ID
+    expect(session.sessionId).toBeNull();
+
+    // Can send messages
+    session.sendMessage("Test message");
+
+    // Can interrupt if available
+    if (session.interrupt) {
+      await session.interrupt();
+    }
+
+    // Can end session
+    session.end();
+
+    // Cannot send after ending
+    expect(() => session.sendMessage("Post-end message")).toThrow();
+  });
+});

--- a/test/integration/providers/claudeCode.integration.test.ts
+++ b/test/integration/providers/claudeCode.integration.test.ts
@@ -9,7 +9,7 @@ import { startPairMcpServer, type PairMcpServer } from '../../../src/mcp/httpSer
 import type { SessionOptions } from '../../../src/providers/types.js';
 
 // Only run integration tests if enabled
-const integrationTestsEnabled = false; //process.env.RUN_INTEGRATION_TESTS;
+const integrationTestsEnabled = process.env.RUN_INTEGRATION_TESTS;
 
 describe.skipIf(!integrationTestsEnabled)("ClaudeCodeProvider Integration", () => {
   let mcpServer: PairMcpServer;

--- a/test/setup-integration.ts
+++ b/test/setup-integration.ts
@@ -1,0 +1,22 @@
+/**
+ * Setup for integration tests
+ * Starts MCP server for tests that need it
+ */
+
+import { startPairMcpServer, type PairMcpServer } from "../src/mcp/httpServer.js";
+
+let mcpServer: PairMcpServer | null = null;
+
+export async function setupMcpServer(): Promise<PairMcpServer> {
+  if (!mcpServer) {
+    mcpServer = await startPairMcpServer();
+  }
+  return mcpServer;
+}
+
+export async function teardownMcpServer(): Promise<void> {
+  if (mcpServer) {
+    await mcpServer.close();
+    mcpServer = null;
+  }
+}

--- a/test/unit/providers/claudeCode.test.ts
+++ b/test/unit/providers/claudeCode.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for ClaudeCodeProvider
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ClaudeCodeProvider } from '../../../src/providers/embedded/claudeCode.js';
+import type { SessionOptions } from '../../../src/providers/types.js';
+
+// Mock the Claude Code SDK
+vi.mock("@anthropic-ai/claude-code", () => ({
+  query: vi.fn().mockReturnValue({
+    [Symbol.asyncIterator]: async function* () {
+      // Mock messages from Claude
+      yield {
+        type: "assistant",
+        session_id: "test-session-123",
+        message: {
+          content: [{
+            type: "text",
+            text: "Hello from mocked Claude"
+          }]
+        }
+      };
+      yield {
+        type: "result",
+        result: "completed"
+      };
+    }
+  }),
+}));
+
+// Mock AsyncUserMessageStream
+vi.mock('../../../src/utils/streamInput.js', () => ({
+  AsyncUserMessageStream: vi.fn().mockImplementation(() => ({
+    pushText: vi.fn(),
+    end: vi.fn(),
+    [Symbol.asyncIterator]: async function* () {
+      yield "test message";
+    }
+  }))
+}));
+
+describe('ClaudeCodeProvider', () => {
+  let provider: ClaudeCodeProvider;
+
+  beforeEach(() => {
+    provider = new ClaudeCodeProvider({ type: 'claude-code' });
+  });
+
+  it('should have correct name and type', () => {
+    expect(provider.name).toBe('claude-code');
+    expect(provider.type).toBe('embedded');
+  });
+
+  it('should create a session with proper options', () => {
+    const options: SessionOptions = {
+      systemPrompt: "Test prompt",
+      allowedTools: ["Read", "Grep"],
+      maxTurns: 5,
+      projectPath: "/test/path",
+      mcpServerUrl: "http://localhost:3000/mcp/navigator",
+      permissionMode: "default",
+    };
+
+    const session = provider.createSession(options);
+
+    expect(session).toBeDefined();
+    expect(session.sessionId).toBe(null); // Initially null
+    expect(typeof session.sendMessage).toBe('function');
+    expect(typeof session.end).toBe('function');
+  });
+
+  it('should handle session message sending', () => {
+    const session = provider.createSession({
+      systemPrompt: "Test",
+      allowedTools: undefined,
+      maxTurns: 5,
+      projectPath: "/test",
+      mcpServerUrl: "http://localhost:3000/mcp/driver",
+    });
+
+    // Should not throw
+    expect(() => session.sendMessage("Test message")).not.toThrow();
+
+    // End session
+    session.end();
+
+    // Should throw after ending
+    expect(() => session.sendMessage("Another message")).toThrow("Cannot send message to ended session");
+  });
+
+  it('should iterate over messages from session', async () => {
+    const session = provider.createSession({
+      systemPrompt: "Test",
+      allowedTools: ["Read"],
+      maxTurns: 5,
+      projectPath: "/test",
+      mcpServerUrl: "http://localhost:3000/mcp/navigator",
+    });
+
+    const messages = [];
+    for await (const message of session) {
+      messages.push(message);
+      if (message.type === 'result') break;
+    }
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0].type).toBe('assistant');
+    expect(messages[1].type).toBe('result');
+
+    // Session ID should be captured
+    expect(session.sessionId).toBe('test-session-123');
+  });
+
+  it('should handle navigator vs driver MCP server URLs', () => {
+    // Test navigator URL
+    const navSession = provider.createSession({
+      systemPrompt: "Navigator test",
+      allowedTools: ["Read"],
+      maxTurns: 5,
+      projectPath: "/test",
+      mcpServerUrl: "http://localhost:3000/mcp/navigator",
+    });
+    expect(navSession).toBeDefined();
+
+    // Test driver URL
+    const driverSession = provider.createSession({
+      systemPrompt: "Driver test",
+      allowedTools: ["all"],
+      maxTurns: 10,
+      projectPath: "/test",
+      mcpServerUrl: "http://localhost:3000/mcp/driver",
+    });
+    expect(driverSession).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Create provider abstraction layer to support multiple coding agent implementations
- Implement ClaudeCodeProvider as the first embedded provider 
- Refactor Architect agent to use provider abstraction
- Add configuration support for selecting agent providers per role
- Fix MCP server cleanup issues that caused test timeouts

## Key Changes

### Provider Abstraction
- **`src/providers/`** - New provider abstraction layer
  - `types.ts` - Interfaces for `AgentProvider`, `EmbeddedAgentProvider`, `ExternalAgentProvider`
  - `factory.ts` - Provider factory with registration system
  - `embedded/claudeCode.ts` - Claude Code provider implementation

### Agent Refactoring  
- **`src/conversations/Architect.ts`** - Now accepts and uses `EmbeddedAgentProvider`
- **`src/index.ts`** - Creates providers from config via factory
- **`src/utils/config.ts`** - Added `architectProvider` configuration

### MCP Server Improvements
- **`src/mcp/httpServer.ts`** - Fixed cleanup to properly close SSE connections
- Prevents hanging during test teardown

### Testing
- **`test/unit/providers/`** - Unit tests for provider abstraction
- **`test/integration/providers/`** - Integration tests for Claude Code provider
- **Updated integration tests** - Use real MCP server for proper testing

## Architecture Benefits

This preserves **MCP as the universal communication protocol** while enabling:
- Mix-and-match agent implementations (Claude Code navigator + Codex driver, etc.)
- Easy addition of new coding agents (OpenCode, etc.)
- Backward compatibility (defaults to Claude Code everywhere)

## Test Plan
- [x] All unit tests pass
- [x] Provider unit tests pass  
- [x] Integration tests pass with real MCP server
- [x] Build succeeds without errors
- [x] Architect agent works with provider abstraction

🤖 Generated with [Claude Code](https://claude.ai/code)