### PR TITLE
Add opencode provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Pair(claude)
+# Pair
 
-Pair is a CLI utility to run two Claude instances in pair programming mode. This experimental CLI application orchestrates two Claude Code instances working together in a pair programming session.
+Pair is a CLI utility that orchestrates coding agents (default: Claude Code) working together in a pair programming session. The driver and navigator roles can now be backed by different providers, including the OpenCode SDK.
 
 ## Overview
 
-This tool creates a collaborative coding session with two Claude instances working together.
+This tool creates a collaborative coding session with two agent instances working together.
 
 - The session starts with a **Planning** phase where a plan is formulated by the Navigator.
 - The plan is then passed to the Driver for **implementation**.
@@ -75,11 +75,42 @@ You can customize behavior using environment variables:
 - `CLAUDE_PAIR_DRIVER_MAX_TURNS`: Maximum turns for driver (default: 20)
 - `CLAUDE_PAIR_MAX_PROMPT_LENGTH`: Maximum prompt length in characters (default: 10000)
 - `CLAUDE_PAIR_MAX_PROMPT_FILE_SIZE`: Maximum prompt file size in bytes (default: 102400 = 100KB)
-- `CLAUDE_PAIR_MODEL`: Claude model to use (default: uses CLI configuration)
+- `CLAUDE_PAIR_MODEL`: Claude model to use when the provider is Claude Code (default: uses CLI configuration)
 - `CLAUDE_PAIR_SESSION_HARD_LIMIT_MIN`: Hard execution time limit in minutes (default: 30)
 - `CLAUDE_PAIR_DISABLE_SYNC_STATUS`: Set to "true" to disable sync status updates in footer (useful for clean recordings)
 
 When the session hard limit is reached during execution, a short notice appears in the footer and both sessions are shut down gracefully.
+
+### Agent Providers
+
+Each role can target a different provider by setting:
+
+- `CLAUDE_PAIR_ARCHITECT_PROVIDER`
+- `CLAUDE_PAIR_NAVIGATOR_PROVIDER`
+- `CLAUDE_PAIR_DRIVER_PROVIDER`
+
+Available values:
+
+- `claude-code` (default)
+- `opencode`
+
+When using the OpenCode provider, make sure an OpenCode server is running and configure it with:
+
+- `OPENCODE_BASE_URL` (defaults to `http://127.0.0.1:4096`)
+- `OPENCODE_MODEL_PROVIDER` / `OPENCODE_MODEL_ID` for the underlying LLM
+- `OPENCODE_AGENT_ARCHITECT`, `OPENCODE_AGENT_NAVIGATOR`, `OPENCODE_AGENT_DRIVER` if you created custom sub-agents with tailored prompts
+- `OPENCODE_START_SERVER=false` if you want to connect to an existing OpenCode deployment instead of auto-starting a local instance
+
+Example:
+
+```bash
+CLAUDE_PAIR_DRIVER_PROVIDER=opencode \
+CLAUDE_PAIR_NAVIGATOR_PROVIDER=opencode \
+OPENCODE_BASE_URL=http://localhost:4096 \
+pair claude --path ~/project -p "Fix flaky tests"
+```
+
+When `opencode` is on your PATH, the provider will automatically launch a local server (`opencode serve`) on `127.0.0.1:4096`. Override the hostname/port with `OPENCODE_HOSTNAME`, `OPENCODE_PORT`, or turn it off entirely with `OPENCODE_START_SERVER=false` and point `OPENCODE_BASE_URL` to a running instance.
 
 ### Debugging and Logging
 - `LOG_LEVEL`: Enable file logging (default: disabled)
@@ -118,8 +149,8 @@ CLAUDE_PAIR_MODEL=claude-3-opus-20240229 \
 When you start the application:
 
 1. You will be prompted to enter a task for the pair to work on
-2. The terminal will display a scrolling list of messages as both Claude instances collaborate
-3. Both Claude instances will begin collaborating on the task
+2. The terminal will display a scrolling list of messages as both agents collaborate
+3. Both agents will begin collaborating on the task
 
 ### Keyboard Shortcuts
 
@@ -141,11 +172,13 @@ src/
 
 - Node.js 18+
 - Claude Code SDK (`@anthropic-ai/claude-code`)
+- OpenCode SDK (`@opencode-ai/sdk`) when using the OpenCode provider
+- OpenCode CLI (`opencode`) on your PATH if you rely on Pair to auto-start the OpenCode server
 - Valid Anthropic API key configured
 
 ## Notes
 
-- Uses your existing Claude authentication. If Claude isn't configured, run `claude` first to set up authentication
+- Uses your existing Claude authentication when the provider is Claude Code. If Claude isn't configured, run `claude` first to set up authentication
 - The two agents can occasionally get into repetitive back‑and‑forth (an implicit "infinite loop"). A hard time limit is enforced for the execution phase (30 minutes by default). You can adjust or disable it via the environment variables documented above.
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pair
 
-Pair is a CLI utility that orchestrates coding agents (default: Claude Code) working together in a pair programming session. The driver and navigator roles can now be backed by different providers, including the OpenCode SDK.
+Pair is a CLI utility that orchestrates coding agents working together in a pair programming session. The architect, navigator, and driver roles can each run on different providers, including Claude Code and the OpenCode SDK.
 
 ## Overview
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@anthropic-ai/claude-code": "^1.0.0",
 				"@anthropic-ai/sdk": "^0.62.0",
 				"@modelcontextprotocol/sdk": "^1.18.0",
+				"@opencode-ai/sdk": "^0.11.1",
 				"ink": "^4.4.1",
 				"marked": "^15.0.12",
 				"marked-terminal": "^7.3.0",
@@ -689,6 +690,53 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@hey-api/json-schema-ref-parser": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.0.6.tgz",
+			"integrity": "sha512-yktiFZoWPtEW8QKS65eqKwA5MTKp88CyiL8q72WynrBs/73SAaxlSWlA2zW/DZlywZ5hX1OYzrCC0wFdvO9c2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@jsdevtools/ono": "^7.1.3",
+				"@types/json-schema": "^7.0.15",
+				"js-yaml": "^4.1.0",
+				"lodash": "^4.17.21"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/hey-api"
+			}
+		},
+		"node_modules/@hey-api/openapi-ts": {
+			"version": "0.81.0",
+			"resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.81.0.tgz",
+			"integrity": "sha512-PoJukNBkUfHOoMDpN33bBETX49TUhy7Hu8Sa0jslOvFndvZ5VjQr4Nl/Dzjb9LG1Lp5HjybyTJMA6a1zYk/q6A==",
+			"license": "MIT",
+			"dependencies": {
+				"@hey-api/json-schema-ref-parser": "1.0.6",
+				"ansi-colors": "4.1.3",
+				"c12": "2.0.1",
+				"color-support": "1.1.3",
+				"commander": "13.0.0",
+				"handlebars": "4.7.8",
+				"js-yaml": "4.1.0",
+				"open": "10.1.2",
+				"semver": "7.7.2"
+			},
+			"bin": {
+				"openapi-ts": "bin/index.cjs"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=22.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/hey-api"
+			},
+			"peerDependencies": {
+				"typescript": "^5.5.3"
+			}
+		},
 		"node_modules/@img/sharp-darwin-arm64": {
 			"version": "0.33.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
@@ -905,6 +953,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@jsdevtools/ono": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+			"integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+			"license": "MIT"
+		},
 		"node_modules/@modelcontextprotocol/sdk": {
 			"version": "1.18.0",
 			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.18.0.tgz",
@@ -926,6 +980,14 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@opencode-ai/sdk": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-0.11.1.tgz",
+			"integrity": "sha512-zlTNXvII/DFhuHO2BIg479kNvhQtSVHhNQdxx2xFjIrqqJs+5/QKPVu1cGekFL2mKCb3hex7dA94tSxH5d41bQ==",
+			"dependencies": {
+				"@hey-api/openapi-ts": "0.81.0"
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1248,6 +1310,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"license": "MIT"
+		},
 		"node_modules/@types/marked-terminal": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/@types/marked-terminal/-/marked-terminal-6.1.1.tgz",
@@ -1428,6 +1496,18 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/acorn": {
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1442,6 +1522,15 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ansi-colors": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/ansi-escapes": {
@@ -1485,6 +1574,12 @@
 			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
 			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
 			"license": "MIT"
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"license": "Python-2.0"
 		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
@@ -1540,6 +1635,21 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"license": "MIT",
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1547,6 +1657,34 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/c12": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/c12/-/c12-2.0.1.tgz",
+			"integrity": "sha512-Z4JgsKXHG37C6PYUtIxCfLJZvo6FyhHJoClwwb9ftUkLpPSkuYqn6Tr+vnaN8hymm0kIbcg6Ey3kv/Q71k5w/A==",
+			"license": "MIT",
+			"dependencies": {
+				"chokidar": "^4.0.1",
+				"confbox": "^0.1.7",
+				"defu": "^6.1.4",
+				"dotenv": "^16.4.5",
+				"giget": "^1.2.3",
+				"jiti": "^2.3.0",
+				"mlly": "^1.7.1",
+				"ohash": "^1.1.4",
+				"pathe": "^1.1.2",
+				"perfect-debounce": "^1.0.0",
+				"pkg-types": "^1.2.0",
+				"rc9": "^2.1.2"
+			},
+			"peerDependencies": {
+				"magicast": "^0.3.5"
+			},
+			"peerDependenciesMeta": {
+				"magicast": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/cac": {
@@ -1636,6 +1774,30 @@
 				"node": ">= 16"
 			}
 		},
+		"node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/chownr": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/ci-info": {
 			"version": "3.9.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -1649,6 +1811,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/citty": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+			"integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+			"license": "MIT",
+			"dependencies": {
+				"consola": "^3.2.3"
 			}
 		},
 		"node_modules/cli-boxes": {
@@ -1950,6 +2121,39 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"license": "MIT"
 		},
+		"node_modules/color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"license": "ISC",
+			"bin": {
+				"color-support": "bin.js"
+			}
+		},
+		"node_modules/commander": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
+			"integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/confbox": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+			"license": "MIT"
+		},
+		"node_modules/consola": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+			"integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^14.18.0 || >=16.10.0"
+			}
+		},
 		"node_modules/content-disposition": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -2059,6 +2263,52 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/default-browser": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+			"integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+			"license": "MIT",
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+			"integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/defu": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+			"license": "MIT"
+		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2066,6 +2316,24 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/destr": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+			"integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+			"license": "MIT"
+		},
+		"node_modules/dotenv": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dunder-proto": {
@@ -2384,6 +2652,30 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/fs-minipass": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/fs-minipass/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2467,6 +2759,30 @@
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
+		"node_modules/giget": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/giget/-/giget-1.2.5.tgz",
+			"integrity": "sha512-r1ekGw/Bgpi3HLV3h1MRBIlSAdHoIMklpaQ3OQLFcRw9PwAj2rqigvIbg+dBUI51OxVI2jsEtDywDBjSiuf7Ug==",
+			"license": "MIT",
+			"dependencies": {
+				"citty": "^0.1.6",
+				"consola": "^3.4.0",
+				"defu": "^6.1.4",
+				"node-fetch-native": "^1.6.6",
+				"nypm": "^0.5.4",
+				"pathe": "^2.0.3",
+				"tar": "^6.2.1"
+			},
+			"bin": {
+				"giget": "dist/cli.mjs"
+			}
+		},
+		"node_modules/giget/node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"license": "MIT"
+		},
 		"node_modules/gopd": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2477,6 +2793,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/handlebars": {
+			"version": "4.7.8",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"wordwrap": "^1.0.0"
+			},
+			"bin": {
+				"handlebars": "bin/handlebars"
+			},
+			"engines": {
+				"node": ">=0.4.7"
+			},
+			"optionalDependencies": {
+				"uglify-js": "^3.1.4"
 			}
 		},
 		"node_modules/has-flag": {
@@ -2657,6 +2994,21 @@
 				"is-ci": "bin.js"
 			}
 		},
+		"node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
@@ -2664,6 +3016,24 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -2693,17 +3063,53 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/is-wsl": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"license": "MIT",
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"license": "ISC"
 		},
+		"node_modules/jiti": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+			"integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"license": "MIT"
+		},
+		"node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -2854,6 +3260,79 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minizlib": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/minizlib/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/mkdirp": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/mlly": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+			"integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"pathe": "^2.0.3",
+				"pkg-types": "^1.3.1",
+				"ufo": "^1.6.1"
+			}
+		},
+		"node_modules/mlly/node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"license": "MIT"
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2899,6 +3378,12 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"license": "MIT"
+		},
 		"node_modules/node-emoji": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -2913,6 +3398,38 @@
 			"engines": {
 				"node": ">=18"
 			}
+		},
+		"node_modules/node-fetch-native": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+			"integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+			"license": "MIT"
+		},
+		"node_modules/nypm": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/nypm/-/nypm-0.5.4.tgz",
+			"integrity": "sha512-X0SNNrZiGU8/e/zAB7sCTtdxWTMSIO73q+xuKgglm2Yvzwlo8UoC5FNySQFCvl84uPaeADkqHUZUkWy4aH4xOA==",
+			"license": "MIT",
+			"dependencies": {
+				"citty": "^0.1.6",
+				"consola": "^3.4.0",
+				"pathe": "^2.0.3",
+				"pkg-types": "^1.3.1",
+				"tinyexec": "^0.3.2",
+				"ufo": "^1.5.4"
+			},
+			"bin": {
+				"nypm": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": "^14.16.0 || >=16.10.0"
+			}
+		},
+		"node_modules/nypm/node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"license": "MIT"
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
@@ -2934,6 +3451,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/ohash": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
+			"integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
+			"license": "MIT"
 		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
@@ -2966,6 +3489,24 @@
 			},
 			"engines": {
 				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
+			"integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+			"license": "MIT",
+			"dependencies": {
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -3033,7 +3574,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
 			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/pathval": {
@@ -3045,6 +3585,12 @@
 			"engines": {
 				"node": ">= 14.16"
 			}
+		},
+		"node_modules/perfect-debounce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+			"integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+			"license": "MIT"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -3061,6 +3607,23 @@
 			"engines": {
 				"node": ">=16.20.0"
 			}
+		},
+		"node_modules/pkg-types": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+			"license": "MIT",
+			"dependencies": {
+				"confbox": "^0.1.8",
+				"mlly": "^1.7.4",
+				"pathe": "^2.0.1"
+			}
+		},
+		"node_modules/pkg-types/node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"license": "MIT"
 		},
 		"node_modules/postcss": {
 			"version": "8.5.6",
@@ -3152,6 +3715,16 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/rc9": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+			"integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+			"license": "MIT",
+			"dependencies": {
+				"defu": "^6.1.4",
+				"destr": "^2.0.3"
+			}
+		},
 		"node_modules/react": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3178,6 +3751,19 @@
 			},
 			"peerDependencies": {
 				"react": "^18.3.1"
+			}
+		},
+		"node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/require-directory": {
@@ -3272,6 +3858,18 @@
 				"node": ">= 18"
 			}
 		},
+		"node_modules/run-applescript": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3305,6 +3903,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/send": {
@@ -3484,6 +4094,15 @@
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
 		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3589,6 +4208,23 @@
 				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
 			}
 		},
+		"node_modules/tar": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+			"license": "ISC",
+			"dependencies": {
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^5.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/thenify": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -3621,7 +4257,6 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
 			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tinypool": {
@@ -3719,7 +4354,6 @@
 			"version": "5.9.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -3727,6 +4361,25 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/ufo": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+			"integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+			"license": "MIT"
+		},
+		"node_modules/uglify-js": {
+			"version": "3.19.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+			"integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/undici-types": {
@@ -4398,6 +5051,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+			"license": "MIT"
+		},
 		"node_modules/wrap-ansi": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -4450,6 +5109,12 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"license": "ISC"
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"@anthropic-ai/claude-code": "^1.0.0",
 		"@anthropic-ai/sdk": "^0.62.0",
 		"@modelcontextprotocol/sdk": "^1.18.0",
+		"@opencode-ai/sdk": "^0.11.1",
 		"ink": "^4.4.1",
 		"marked": "^15.0.12",
 		"marked-terminal": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"watch": "tsc --watch",
 		"lint": "biome lint src/",
 		"format": "biome format --write src/",
-		"check": "biome check --write src/",
+		"check": "biome check --write src/ --max-diagnostics 100",
 		"prepare": "husky",
 		"test": "vitest run",
 		"test:watch": "vitest",

--- a/src/components/ConversationView.tsx
+++ b/src/components/ConversationView.tsx
@@ -100,6 +100,7 @@ const ConversationView: React.FC<Props> = React.memo(({ messages, phase }) => {
 				if (message.content?.includes("Starting pair coding session")) {
 					hasSeenTransition = true;
 					isFirstDriverMessage = true;
+					lastRole = undefined;
 				}
 
 				nodes.push(

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, useInput } from "ink";
 import type React from "react";
 import { hasAbsolutelyRightPhrase, useAbsRight } from "../hooks/useAbsRight.js";
-import type { SessionPhase } from "../types.js";
+import type { AgentProviders, SessionPhase } from "../types.js";
 
 interface Props {
 	onExit: () => void;
@@ -10,6 +10,7 @@ interface Props {
 	quitState?: "normal" | "confirm";
 	onCtrlC?: () => void;
 	allMessages?: string; // Combined content of recent messages for detection
+	providers?: AgentProviders;
 }
 
 const Footer: React.FC<Props> = ({
@@ -19,6 +20,7 @@ const Footer: React.FC<Props> = ({
 	quitState = "normal",
 	onCtrlC,
 	allMessages = "",
+	providers,
 }) => {
 	const hasPhrase = hasAbsolutelyRightPhrase(allMessages);
 	const absRightColor = useAbsRight(hasPhrase);
@@ -35,6 +37,21 @@ const Footer: React.FC<Props> = ({
 	const terminalWidth = process.stdout.columns || 80;
 	const horizontalLine = "─".repeat(terminalWidth);
 
+	const segments: string[] = [];
+	if (phase) {
+		segments.push(`Phase: ${phase[0].toUpperCase()}${phase.slice(1)}`);
+	}
+	if (activity) {
+		segments.push(activity);
+	}
+	if (providers) {
+		segments.push(
+			`A:${providers.architect} | N:${providers.navigator} | D:${providers.driver}`,
+		);
+	}
+
+	const leftText = segments.join("  •  ") || " ";
+
 	return (
 		<Box flexDirection="column">
 			<Text color="gray">{horizontalLine}</Text>
@@ -46,8 +63,7 @@ const Footer: React.FC<Props> = ({
 					backgroundColor={absRightColor || undefined}
 					color={absRightColor ? "black" : "gray"}
 				>
-					{phase ? `Phase: ${phase[0].toUpperCase()}${phase.slice(1)}` : ""}
-					{activity ? `  •  ${activity}` : ""}
+					{leftText}
 				</Text>
 				<Text
 					backgroundColor={absRightColor || undefined}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -45,9 +45,13 @@ const Footer: React.FC<Props> = ({
 		segments.push(activity);
 	}
 	if (providers) {
-		segments.push(
-			`A:${providers.architect} | N:${providers.navigator} | D:${providers.driver}`,
-		);
+		if (phase === "planning") {
+			segments.push(`Architect: ${providers.architect}`);
+		} else if (phase === "execution" || phase === "review") {
+			segments.push(
+				`Navigator: ${providers.navigator} | Driver: ${providers.driver}`,
+			);
+		}
 	}
 
 	const leftText = segments.join("  •  ") || " ";

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -39,7 +39,7 @@ const Footer: React.FC<Props> = ({
 
 	const segments: string[] = [];
 	if (phase) {
-		segments.push(`Phase: ${phase[0].toUpperCase()}${phase.slice(1)}`);
+		segments.push(`${phase[0].toUpperCase()}${phase.slice(1)}`);
 	}
 	if (activity) {
 		segments.push(activity);

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -38,13 +38,9 @@ const Footer: React.FC<Props> = ({
 	const horizontalLine = "─".repeat(terminalWidth);
 
 	const segments: string[] = [];
-	if (phase) {
-		segments.push(`${phase[0].toUpperCase()}${phase.slice(1)}`);
-	}
 	if (activity) {
 		segments.push(activity);
-	}
-	if (providers) {
+	} else if (providers) {
 		if (phase === "planning") {
 			segments.push(`Architect: ${providers.architect}`);
 		} else if (phase === "execution" || phase === "review") {

--- a/src/components/PairProgrammingApp.tsx
+++ b/src/components/PairProgrammingApp.tsx
@@ -43,6 +43,7 @@ const PairProgrammingApp: React.FC<Props> = ({ state, onExit, onCtrlC }) => {
 				quitState={state.quitState}
 				onCtrlC={onCtrlC}
 				allMessages={recentContent}
+				providers={state.providers}
 			/>
 		</Box>
 	);

--- a/src/conversations/Architect.ts
+++ b/src/conversations/Architect.ts
@@ -13,6 +13,7 @@ import type { Logger } from "../utils/logger.js";
 export class Architect extends EventEmitter {
 	private sessionId: string | null = null;
 	private session: AgentSession | null = null;
+	private detectPlanCompletion?: (message: any) => string | null;
 
 	constructor(
 		private systemPrompt: string,
@@ -43,16 +44,14 @@ export class Architect extends EventEmitter {
 			const toolsToPass = isAllToolsEnabled(this.allowedTools)
 				? undefined
 				: this.allowedTools;
-			const isOpenCodeProvider = this.provider.name === "opencode";
 
-			// Create session with provider
-			// Note: Architect doesn't use MCP server, but we keep the parameter for consistency
+			// Create session with provider and MCP server for completePlan tool
 			this.session = this.provider.createSession({
 				systemPrompt: this.systemPrompt,
 				allowedTools: toolsToPass,
 				maxTurns: this.maxTurns,
 				projectPath: this.projectPath,
-				mcpServerUrl: this.mcpServerUrl || "", // Empty for Architect since it doesn't use MCP
+				mcpServerUrl: this.mcpServerUrl || "",
 				permissionMode: "plan",
 				diagnosticLogger: (event, data) => {
 					this.logger.logEvent(event, {
@@ -63,10 +62,10 @@ export class Architect extends EventEmitter {
 				},
 			});
 
-			// Send the initial prompt - adjust based on provider
-			const prompt = isOpenCodeProvider
-				? `Our task is to: ${task}\n\nPlease create a clear, step-by-step implementation plan tailored to this repository.\n- Focus on concrete steps, specific files, and commands.\n- Keep it concise and actionable.\n- Do not implement changes now.\n\nEnd your response with "PLAN COMPLETE" when you finish the plan.`
-				: `Our task is to: ${task}\n\nPlease create a clear, step-by-step implementation plan tailored to this repository.\n- Focus on concrete steps, specific files, and commands.\n- Keep it concise and actionable.\n- Do not implement changes now.\n\nWhen your plan is ready, call the ExitPlanMode tool with { plan: <your full plan> } to finish planning.`;
+			// Get provider-specific prompt and completion logic
+			const { prompt, detectPlanCompletion } =
+				this.provider.getPlanningConfig(task);
+			this.detectPlanCompletion = detectPlanCompletion;
 			this.session.sendMessage(prompt);
 
 			for await (const message of this.session) {
@@ -112,16 +111,6 @@ export class Architect extends EventEmitter {
 									sessionRole: "architect" as Role,
 									timestamp: new Date(),
 								});
-
-								// For OpenCode, check if plan is complete based on text content
-								if (isOpenCodeProvider && text.includes("PLAN COMPLETE")) {
-									plan = _fullText.replace("PLAN COMPLETE", "").trim();
-									this.logger.logEvent("ARCHITECT_PLAN_CREATED_FROM_TEXT", {
-										planLength: (plan ?? "").length,
-										turnCount,
-									});
-									return plan;
-								}
 							} else if (item.type === "tool_use") {
 								// Emit tool usage
 								this.emit("tool_use", {
@@ -129,43 +118,21 @@ export class Architect extends EventEmitter {
 									tool: item.name,
 									input: item.input,
 								});
-
-								// Detect plan completion via ExitPlanMode tool (Claude Code)
-								// biome-ignore lint/suspicious/noExplicitAny: Provider tool item structure
-								const it: any = item as any;
-								if (it.name === "ExitPlanMode" && it.input?.plan) {
-									plan = it.input.plan as string;
-									this.logger.logEvent("ARCHITECT_PLAN_CREATED", {
-										planLength: (plan ?? "").length,
-										turnCount,
-									});
-									// Robust early-exit: as soon as ExitPlanMode is called with a plan,
-									// return the plan without waiting for a tool_result from the host.
-									// This avoids environments that don't implement the ExitPlanMode tool_result handshake.
-									this.logger.logEvent("ARCHITECT_EARLY_RETURN_AFTER_PLAN", {
-										reason: "exit_plan_mode_called",
-										turnCount,
-									});
-									return plan;
-								}
 							}
 						}
 
-						// For OpenCode, also check if we have accumulated a complete plan
-						if (
-							isOpenCodeProvider &&
-							_fullText.includes("PLAN COMPLETE") &&
-							!plan
-						) {
-							plan = _fullText.replace("PLAN COMPLETE", "").trim();
-							this.logger.logEvent("ARCHITECT_PLAN_CREATED_FROM_FULLTEXT", {
-								planLength: (plan ?? "").length,
-								turnCount,
-							});
-							return plan;
+						// Use provider-specific completion detection
+						if (this.detectPlanCompletion) {
+							const detectedPlan = this.detectPlanCompletion(message);
+							if (detectedPlan) {
+								plan = detectedPlan;
+								this.logger.logEvent("ARCHITECT_PLAN_CREATED", {
+									planLength: (plan ?? "").length,
+									turnCount,
+								});
+								return plan;
+							}
 						}
-
-						// No fallback text capture for Claude Code — plan must be returned via ExitPlanMode tool
 					}
 				}
 			}

--- a/src/conversations/Driver.ts
+++ b/src/conversations/Driver.ts
@@ -189,6 +189,13 @@ export class Driver extends EventEmitter {
 			canUseTool: this.canUseTool,
 			disallowedTools: [],
 			includePartialMessages: true,
+			diagnosticLogger: (event, data) => {
+				this.logger.logEvent(event, {
+					agent: "driver",
+					provider: this.provider.name,
+					...data,
+				});
+			},
 		});
 
 		// Use the session's input stream
@@ -526,7 +533,8 @@ export class Driver extends EventEmitter {
 		toolName: string,
 		input: any,
 	): DriverCommand | null {
-		switch (toolName) {
+		const normalized = Driver.normalizeDriverTool(toolName);
+		switch (normalized) {
 			case "mcp__driver__driverRequestReview":
 				return {
 					type: "request_review",
@@ -540,6 +548,16 @@ export class Driver extends EventEmitter {
 			default:
 				return null;
 		}
+	}
+
+	private static normalizeDriverTool(toolName: string): string {
+		if (toolName.startsWith("mcp__driver__")) {
+			return toolName;
+		}
+		if (toolName.startsWith("pair-driver_")) {
+			return `mcp__driver__${toolName.slice("pair-driver_".length)}`;
+		}
+		return toolName;
 	}
 
 	/**

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,7 +1,22 @@
 import { useCallback, useState } from "react";
-import type { Message, PairProgrammingState, SessionPhase } from "../types.js";
+import type {
+	AgentProviders,
+	Message,
+	PairProgrammingState,
+	SessionPhase,
+} from "../types.js";
 
-export const useMessages = (projectPath: string, initialTask: string) => {
+const UNKNOWN_PROVIDERS: AgentProviders = {
+	architect: "unknown",
+	navigator: "unknown",
+	driver: "unknown",
+};
+
+export const useMessages = (
+	projectPath: string,
+	initialTask: string,
+	providers: AgentProviders = UNKNOWN_PROVIDERS,
+) => {
 	const [state, setState] = useState<PairProgrammingState>({
 		projectPath,
 		initialTask,
@@ -10,6 +25,7 @@ export const useMessages = (projectPath: string, initialTask: string) => {
 		currentActivity: "",
 		phase: "planning",
 		quitState: "normal",
+		providers,
 	});
 
 	const addMessage = useCallback((message: Message) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -472,8 +472,10 @@ class ClaudePairApp {
 						},
 					);
 					// biome-ignore lint/suspicious/noExplicitAny: Navigator command response type from Claude Code SDK
-					const _navResp: any =
-						await this.navigator.processDriverMessage(messageForNavigator);
+					const _navResp: any = await this.navigator.processDriverMessage(
+						messageForNavigator,
+						true,
+					); // true = review was requested
 					// biome-ignore lint/suspicious/noExplicitAny: Navigator command array type from Claude Code SDK
 					const navCommands: any[] = Array.isArray(_navResp)
 						? _navResp
@@ -541,8 +543,10 @@ class ClaudePairApp {
 						while (attempts < 5) {
 							attempts++;
 							const retryPrompt = `${messageForNavigator}\n\nSTRICT: Respond with exactly one MCP tool call: mcp__navigator__navigatorCodeReview OR mcp__navigator__navigatorComplete. No other text.`;
-							const retryResp =
-								await this.navigator.processDriverMessage(retryPrompt);
+							const retryResp = await this.navigator.processDriverMessage(
+								retryPrompt,
+								true,
+							); // true = still reviewing
 							const cmds: NavigatorCommand[] = Array.isArray(retryResp)
 								? retryResp
 								: retryResp
@@ -636,9 +640,11 @@ class ClaudePairApp {
 							messageLength: combinedMessage.length,
 						},
 					);
-					// Process guidance request with navigator
-					const _navResp: any =
-						await this.navigator.processDriverMessage(combinedMessage);
+					// Process guidance request with navigator (not a review)
+					const _navResp: any = await this.navigator.processDriverMessage(
+						combinedMessage,
+						false,
+					);
 					const navCommands: any[] = Array.isArray(_navResp)
 						? _navResp
 						: _navResp

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,20 +196,9 @@ class ClaudePairApp {
 		const drvUrl = this.mcp.urls.driver;
 		this.logger.logEvent("APP_MCP_URLS", { navUrl, drvUrl });
 
-		const makeProviderConfig = (providerType: string): ProviderConfig => {
-			if (providerType === "opencode") {
-				return {
-					type: providerType,
-					options: {
-						mcpServers: {
-							"pair-navigator": { url: navUrl },
-							"pair-driver": { url: drvUrl },
-						},
-					},
-				};
-			}
-			return { type: providerType };
-		};
+		const makeProviderConfig = (providerType: string): ProviderConfig => ({
+			type: providerType,
+		});
 
 		// Create providers for all agents
 		const architectProvider = agentProviderFactory.createProvider(

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ import type {
 	EmbeddedAgentProvider,
 	ProviderConfig,
 } from "./providers/types.js";
-import { isEmbeddedProvider } from "./providers/types.js";
 import { isFileModificationTool } from "./types/core.js";
 import {
 	NavigatorSessionError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,8 +235,7 @@ class ClaudePairApp {
 			this.projectPath,
 			this.logger,
 			architectProvider,
-			// Architect doesn't use MCP server, but we can pass empty string
-			"",
+			"", // Architect doesn't use MCP server for this approach
 		);
 
 		this.navigator = new Navigator(

--- a/src/providers/embedded/base.ts
+++ b/src/providers/embedded/base.ts
@@ -44,6 +44,15 @@ export abstract class BaseEmbeddedProvider implements EmbeddedAgentProvider {
 	}
 
 	/**
+	 * Get provider-specific planning configuration
+	 * Must be implemented by concrete providers
+	 */
+	abstract getPlanningConfig(task: string): {
+		prompt: string;
+		detectPlanCompletion: (message: any) => string | null;
+	};
+
+	/**
 	 * Optional cleanup
 	 */
 	async cleanup(): Promise<void> {

--- a/src/providers/embedded/claudeCode.ts
+++ b/src/providers/embedded/claudeCode.ts
@@ -233,4 +233,31 @@ export class ClaudeCodeProvider extends BaseEmbeddedProvider {
 	): StreamingAgentSession {
 		return new ClaudeCodeStreamingSession(options);
 	}
+
+	getPlanningConfig(task: string): {
+		prompt: string;
+		detectPlanCompletion: (message: any) => string | null;
+	} {
+		return {
+			prompt: `Our task is to: ${task}\n\nPlease create a clear, step-by-step implementation plan tailored to this repository.\n- Focus on concrete steps, specific files, and commands.\n- Keep it concise and actionable.\n- Do not implement changes now.\n\nWhen your plan is ready, call the ExitPlanMode tool with { plan: <your full plan> } to finish planning.`,
+			detectPlanCompletion: (message) => {
+				// Detect ExitPlanMode tool usage
+				if (
+					message.message?.content &&
+					Array.isArray(message.message.content)
+				) {
+					for (const item of message.message.content) {
+						if (
+							item.type === "tool_use" &&
+							item.name === "ExitPlanMode" &&
+							item.input?.plan
+						) {
+							return item.input.plan as string;
+						}
+					}
+				}
+				return null;
+			},
+		};
+	}
 }

--- a/src/providers/embedded/claudeCode.ts
+++ b/src/providers/embedded/claudeCode.ts
@@ -12,11 +12,8 @@ import type {
 	AgentInputStream,
 	AgentMessage,
 	AgentSession,
-	CanUseToolFunction,
-	McpServerConfig,
 	SessionOptions,
 	StreamingAgentSession,
-	StreamingCanUseToolFunction,
 	StreamingSessionOptions,
 } from "../types.js";
 import { BaseEmbeddedProvider } from "./base.js";

--- a/src/providers/embedded/openCode.ts
+++ b/src/providers/embedded/openCode.ts
@@ -1,0 +1,1243 @@
+import type {
+	Event,
+	EventMessagePartRemoved,
+	EventMessagePartUpdated,
+	EventMessageUpdated,
+	EventPermissionUpdated,
+	Part,
+	Path,
+	Permission,
+	Project,
+	Session,
+	SessionPromptResponse,
+} from "@opencode-ai/sdk";
+import { createOpencodeClient, createOpencodeServer } from "@opencode-ai/sdk";
+import { z } from "zod";
+import type {
+	AgentInputStream,
+	AgentMessage,
+	AgentSession,
+	DiagnosticLogger,
+	ProviderConfig,
+	SessionOptions,
+	StreamingAgentSession,
+	StreamingSessionOptions,
+} from "../types.js";
+import { BaseEmbeddedProvider } from "./base.js";
+import {
+	normalizeToolInput,
+	resolvePermissionToolName,
+	resolveToolName,
+} from "./openCode/normalization.js";
+
+const DEFAULT_BASE_URL =
+	process.env.OPENCODE_BASE_URL || "http://127.0.0.1:4096";
+const DEFAULT_SERVER_HOST = process.env.OPENCODE_HOSTNAME || "127.0.0.1";
+const ENV_SERVER_PORT = Number.parseInt(
+	process.env.OPENCODE_PORT || "4096",
+	10,
+);
+const DEFAULT_SERVER_PORT = Number.isNaN(ENV_SERVER_PORT)
+	? 4096
+	: ENV_SERVER_PORT;
+const ENV_SERVER_TIMEOUT = Number.parseInt(
+	process.env.OPENCODE_SERVER_TIMEOUT || "5000",
+	10,
+);
+const DEFAULT_SERVER_TIMEOUT = Number.isNaN(ENV_SERVER_TIMEOUT)
+	? 5000
+	: ENV_SERVER_TIMEOUT;
+const DEFAULT_MODEL_PROVIDER_ID =
+	process.env.OPENCODE_MODEL_PROVIDER || "openrouter";
+const DEFAULT_MODEL_ID =
+	process.env.OPENCODE_MODEL_ID || "google/gemini-2.5-pro";
+const ENV_AGENT_ARCHITECT = process.env.OPENCODE_AGENT_ARCHITECT;
+const ENV_AGENT_NAVIGATOR = process.env.OPENCODE_AGENT_NAVIGATOR;
+const ENV_AGENT_DRIVER = process.env.OPENCODE_AGENT_DRIVER;
+
+type OpenCodeClient = ReturnType<typeof createOpencodeClient>;
+
+const McpServerSchema = z.union([
+	z.string(),
+	z.object({
+		url: z.string(),
+		enabled: z.boolean().optional(),
+		headers: z.record(z.string(), z.string()).optional(),
+	}),
+]);
+
+const OpenCodeOptionsSchema = z
+	.object({
+		baseUrl: z.string().optional(),
+		directory: z.string().optional(),
+		apiKey: z.string().optional(),
+		model: z
+			.object({
+				providerId: z.string(),
+				modelId: z.string(),
+			})
+			.optional(),
+		agents: z
+			.object({
+				architect: z.string().optional(),
+				navigator: z.string().optional(),
+				driver: z.string().optional(),
+			})
+			.optional(),
+		mcpServers: z.record(McpServerSchema).optional(),
+		startServer: z.boolean().optional(),
+		server: z
+			.object({
+				hostname: z.string().optional(),
+				port: z.number().optional(),
+				timeout: z.number().optional(),
+				config: z.record(z.string(), z.unknown()).optional(),
+			})
+			.optional(),
+	})
+	.default({});
+
+type OpenCodeOptions = z.infer<typeof OpenCodeOptionsSchema>;
+
+type ToolPermissionResult =
+	| {
+			behavior: "allow";
+			updatedInput: Record<string, unknown>;
+			updatedPermissions?: Record<string, unknown>;
+	  }
+	| { behavior: "deny"; message: string };
+
+type ToolGuard = (
+	toolName: string,
+	input: Record<string, unknown>,
+) => Promise<ToolPermissionResult>;
+
+interface ModelConfig {
+	providerId: string;
+	modelId: string;
+}
+
+interface AgentNames {
+	architect?: string;
+	navigator?: string;
+	driver?: string;
+}
+
+interface RemoteMcpServerConfig {
+	url: string;
+	enabled?: boolean;
+	headers?: Record<string, string>;
+}
+
+interface OpenCodeProviderConfig {
+	baseUrl?: string;
+	directory?: string;
+	model: ModelConfig;
+	agents: AgentNames;
+	startServer: boolean;
+	server?: ServerOptions;
+	mcpServers?: Record<string, RemoteMcpServerConfig>;
+}
+
+interface SessionConfigBase {
+	role: "architect" | "navigator" | "driver";
+	systemPrompt: string;
+	directory?: string;
+	model: ModelConfig;
+	agentName?: string;
+	canUseTool?: ToolGuard;
+	includePartialMessages: boolean;
+	diagnosticLogger?: DiagnosticLogger;
+}
+
+type StreamingSessionConfig = SessionConfigBase;
+type ArchitectSessionConfig = SessionConfigBase;
+
+interface ServerOptions {
+	hostname?: string;
+	port?: number;
+	timeout?: number;
+	config?: Record<string, unknown>;
+	workingDirectory?: string;
+}
+
+interface SharedServerLease {
+	url: string;
+	release(): void;
+}
+
+interface SharedServerRecord {
+	refCount: number;
+	handlePromise: Promise<{ url: string; close(): void }>;
+}
+
+const sharedServerRegistry = new Map<string, SharedServerRecord>();
+
+function stableStringify(value: unknown): string {
+	if (value === null || typeof value !== "object") {
+		return JSON.stringify(value);
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+	}
+	const entries = Object.entries(value as Record<string, unknown>).sort(
+		(a, b) => a[0].localeCompare(b[0]),
+	);
+	return `{${entries
+		.map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`)
+		.join(",")}}`;
+}
+
+function buildServerKey(options: ServerOptions): string {
+	return stableStringify({
+		hostname: options.hostname,
+		port: options.port,
+		timeout: options.timeout,
+		config: options.config ?? {},
+		workingDirectory: options.workingDirectory ?? null,
+	});
+}
+
+function releaseSharedServer(key: string): void {
+	const record = sharedServerRegistry.get(key);
+	if (!record) return;
+	record.refCount = Math.max(0, record.refCount - 1);
+	if (record.refCount === 0) {
+		sharedServerRegistry.delete(key);
+		record.handlePromise
+			.then((handle) => {
+				try {
+					handle.close();
+				} catch {}
+			})
+			.catch(() => {
+				// Server failed to start; nothing to close.
+			});
+	}
+}
+
+async function startOpencodeServer(
+	options: ServerOptions,
+): Promise<{ url: string; close(): void }> {
+	const { hostname, port, timeout, config } = options;
+
+	try {
+		const server = await createOpencodeServer({
+			hostname,
+			port,
+			timeout,
+			config,
+		});
+
+		return server;
+	} catch (error) {
+		throw new Error(
+			`Failed to start OpenCode server: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+async function acquireSharedServer(
+	options: ServerOptions,
+): Promise<SharedServerLease> {
+	const key = buildServerKey(options);
+	let record = sharedServerRegistry.get(key);
+	if (!record) {
+		const handlePromise = startOpencodeServer(options);
+		record = {
+			refCount: 0,
+			handlePromise,
+		};
+		sharedServerRegistry.set(key, record);
+	}
+
+	record.refCount += 1;
+
+	try {
+		const handle = await record.handlePromise;
+		let released = false;
+		return {
+			url: handle.url,
+			release: () => {
+				if (released) return;
+				released = true;
+				releaseSharedServer(key);
+			},
+		};
+	} catch (error) {
+		releaseSharedServer(key);
+		throw error;
+	}
+}
+
+class AsyncMessageQueue<T> implements AsyncIterable<T> {
+	private readonly queue: T[] = [];
+	private readonly resolvers: Array<(value: IteratorResult<T, void>) => void> =
+		[];
+	private done = false;
+	private error: unknown = null;
+
+	push(value: T): void {
+		if (this.done) return;
+		if (this.resolvers.length > 0) {
+			const resolve = this.resolvers.shift();
+			resolve?.({ value, done: false });
+		} else {
+			this.queue.push(value);
+		}
+	}
+
+	finish(): void {
+		if (this.done) return;
+		this.done = true;
+		while (this.resolvers.length > 0) {
+			const resolve = this.resolvers.shift();
+			resolve?.({ value: undefined, done: true });
+		}
+	}
+
+	throw(error: unknown): void {
+		if (this.done) return;
+		this.error = error;
+		this.done = true;
+		while (this.resolvers.length > 0) {
+			const resolve = this.resolvers.shift();
+			if (resolve) {
+				resolve({
+					// biome-ignore lint/suspicious/noExplicitAny: Async iterator error propagation
+					value: undefined as any,
+					done: true,
+				});
+			}
+		}
+	}
+
+	private async next(): Promise<IteratorResult<T, void>> {
+		if (this.error) {
+			// biome-ignore lint/suspicious/noExplicitAny: Async iterator error propagation
+			throw this.error;
+		}
+
+		if (this.queue.length > 0) {
+			const value = this.queue.shift()!;
+			return { value, done: false };
+		}
+
+		if (this.done) {
+			return { value: undefined, done: true };
+		}
+
+		return new Promise<IteratorResult<T, void>>((resolve) => {
+			this.resolvers.push(resolve);
+		});
+	}
+
+	[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
+		return {
+			next: () => this.next(),
+		};
+	}
+}
+
+function hasCompletedTimestamp(info: unknown): boolean {
+	if (!info || typeof info !== "object") return false;
+	const time = (info as { time?: unknown }).time;
+	if (!time || typeof time !== "object") return false;
+	if ("completed" in time) {
+		const value = (time as Record<string, unknown>).completed;
+		return value !== undefined && value !== null;
+	}
+	return false;
+}
+
+function unwrapData<T>(
+	result: T | { data: T | undefined; error?: unknown },
+): T {
+	if (result && typeof result === "object" && "data" in result) {
+		const { data, error } = result as { data: T | undefined; error?: unknown };
+		if (!data) {
+			const message =
+				error && typeof error === "object" && "message" in error
+					? String((error as { message?: unknown }).message)
+					: "OpenCode request failed";
+			throw new Error(message);
+		}
+		return data;
+	}
+	return result as T;
+}
+
+function buildPlanTitle(role: string): string {
+	return `pair-${role}-${new Date().toISOString()}`;
+}
+
+type OpenCodeToolStateStatus = "pending" | "running" | "completed" | "error";
+
+class OpenCodeSessionBase implements AsyncIterable<AgentMessage> {
+	public sessionId: string | null = null;
+	protected readonly queue = new AsyncMessageQueue<AgentMessage>();
+	protected readonly reasoningParts = new Map<string, string>();
+	protected readonly toolStates = new Map<string, OpenCodeToolStateStatus>();
+	protected readonly partMetadata = new Map<
+		string,
+		{ messageId: string; text: string }
+	>();
+	protected readonly messageBuffers = new Map<string, string>();
+	protected readonly messagePartIds = new Map<string, Set<string>>();
+	protected readonly emittedMessages = new Set<string>();
+
+	private readonly promptQueue: string[] = [];
+	private processing = false;
+	private closed = false;
+	private eventAbort?: AbortController;
+	private eventLoopPromise?: Promise<void>;
+	private readonly directory?: string;
+	private readonly guard?: ToolGuard;
+	private readonly includePartialMessages: boolean;
+	private readonly initialized: Promise<void>;
+	private readonly clientFactory: () => Promise<OpenCodeClient>;
+	protected client!: OpenCodeClient;
+	private readonly diagnosticLogger?: DiagnosticLogger;
+	private toolIdsLogged = false;
+
+	constructor(
+		clientFactory: () => Promise<OpenCodeClient>,
+		private readonly config: SessionConfigBase,
+	) {
+		this.clientFactory = clientFactory;
+		this.directory = config.directory;
+		this.guard = config.canUseTool;
+		this.includePartialMessages = config.includePartialMessages;
+		this.diagnosticLogger = config.diagnosticLogger;
+		this.initialized = this.initialize();
+	}
+
+	protected get role(): "architect" | "navigator" | "driver" {
+		return this.config.role;
+	}
+
+	protected logDiagnostic(
+		event: string,
+		data: Record<string, unknown> = {},
+	): void {
+		try {
+			this.diagnosticLogger?.(event, {
+				role: this.role,
+				sessionId: this.sessionId ?? undefined,
+				...data,
+			});
+		} catch {
+			// Swallow logging failures to avoid breaking execution
+		}
+	}
+
+	private async logAvailableTools(): Promise<void> {
+		if (this.toolIdsLogged) return;
+		if (!this.client || typeof this.client.tool?.ids !== "function") {
+			this.toolIdsLogged = true;
+			return;
+		}
+		try {
+			const idsResult = await this.client.tool.ids({});
+			const ids = Array.isArray(idsResult)
+				? idsResult
+				: Array.isArray((idsResult as any)?.data)
+					? ((idsResult as any).data as unknown[])
+					: undefined;
+			if (Array.isArray(ids)) {
+				this.logDiagnostic("OPENCODE_TOOL_IDS", {
+					ids,
+				});
+			}
+		} catch (error) {
+			this.logDiagnostic("OPENCODE_TOOL_IDS_ERROR", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		} finally {
+			this.toolIdsLogged = true;
+		}
+	}
+
+	protected async initialize(): Promise<void> {
+		this.client = await this.clientFactory();
+		this.logDiagnostic("OPENCODE_INIT_CLIENT", {
+			directory: this.directory,
+			agent: this.config.agentName,
+		});
+		const sessionResult = await this.client.session.create({
+			body: { title: buildPlanTitle(this.role) },
+			query: this.directory ? { directory: this.directory } : undefined,
+		});
+		const session = unwrapData<Session>(sessionResult);
+		this.sessionId = session.id;
+		this.logDiagnostic("OPENCODE_SESSION_CREATED", {
+			sessionTitle: session.title,
+		});
+		await this.startEventStream();
+		void this.logAvailableTools();
+		if (this.directory) {
+			try {
+				const pathInfoResult = await this.client.path.get({
+					query: { directory: this.directory },
+				});
+				const pathInfo = unwrapData<Path>(pathInfoResult);
+				this.logDiagnostic("OPENCODE_PATH_STATUS", {
+					state: pathInfo.state,
+					worktree: pathInfo.worktree,
+					directory: pathInfo.directory,
+				});
+			} catch (error) {
+				this.logDiagnostic("OPENCODE_PATH_STATUS_ERROR", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+			try {
+				const projectInfoResult = await this.client.project.current({
+					query: { directory: this.directory },
+				});
+				const projectInfo = unwrapData<Project>(projectInfoResult);
+				this.logDiagnostic("OPENCODE_PROJECT_STATUS", {
+					projectId: projectInfo.id,
+					worktree: projectInfo.worktree,
+				});
+			} catch (error) {
+				this.logDiagnostic("OPENCODE_PROJECT_STATUS_ERROR", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		}
+	}
+
+	protected async startEventStream(): Promise<void> {
+		this.eventAbort = new AbortController();
+		this.logDiagnostic("OPENCODE_EVENT_STREAM_SUBSCRIBE", {});
+		const events = await this.client.event.subscribe({
+			signal: this.eventAbort.signal,
+			query: this.directory ? { directory: this.directory } : undefined,
+		});
+		this.eventLoopPromise = this.processEvents(events.stream);
+	}
+
+	protected async processEvents(stream: AsyncGenerator<Event>): Promise<void> {
+		try {
+			for await (const event of stream) {
+				if (this.closed) break;
+				if (!this.sessionId) continue;
+				this.logDiagnostic("OPENCODE_EVENT_RECEIVED", {
+					eventType: event.type,
+				});
+				switch (event.type) {
+					case "permission.updated": {
+						await this.handlePermission(event as EventPermissionUpdated);
+						break;
+					}
+					case "message.updated": {
+						this.handleMessageUpdated(event as EventMessageUpdated);
+						break;
+					}
+					case "message.part.updated": {
+						this.handlePartUpdated(event as EventMessagePartUpdated);
+						break;
+					}
+					case "message.part.removed": {
+						this.handlePartRemoved(event as EventMessagePartRemoved);
+						break;
+					}
+					default:
+						break;
+				}
+			}
+		} catch (error) {
+			if (!this.closed) {
+				this.queue.throw(error);
+			}
+		}
+	}
+
+	protected handleMessageUpdated(event: EventMessageUpdated): void {
+		if (event.properties.info.sessionID !== this.sessionId) return;
+		const info = event.properties.info;
+		this.logDiagnostic("OPENCODE_MESSAGE_UPDATED", {
+			messageId: info.id,
+			role: info.role,
+		});
+		if (info.role === "assistant" && info.error) {
+			const message =
+				typeof info.error === "object" &&
+				"data" in info.error &&
+				info.error.data &&
+				typeof info.error.data === "object" &&
+				"message" in info.error.data
+					? String((info.error.data as Record<string, unknown>).message)
+					: "Assistant error";
+			this.logDiagnostic("OPENCODE_ASSISTANT_ERROR", {
+				errorMessage: message,
+			});
+			this.queue.push({
+				type: "system",
+				session_id: this.sessionId ?? undefined,
+				subtype: "assistant_error",
+				message: { content: message },
+			});
+		}
+
+		if (
+			!this.includePartialMessages &&
+			info.role === "assistant" &&
+			info.time?.completed !== undefined &&
+			!this.emittedMessages.has(info.id)
+		) {
+			const buffer = this.messageBuffers.get(info.id);
+			if (buffer && buffer.trim()) {
+				this.queue.push({
+					type: "assistant",
+					session_id: this.sessionId ?? undefined,
+					message: {
+						content: [{ type: "text", text: buffer }],
+					},
+				});
+			}
+			this.emittedMessages.add(info.id);
+			const partIds = this.messagePartIds.get(info.id);
+			if (partIds) {
+				for (const partId of partIds) {
+					this.partMetadata.delete(partId);
+				}
+			}
+			this.messageBuffers.delete(info.id);
+			this.messagePartIds.delete(info.id);
+		}
+	}
+
+	protected handlePartRemoved(event: EventMessagePartRemoved): void {
+		if (event.properties.sessionID !== this.sessionId) return;
+		this.reasoningParts.delete(event.properties.partID);
+		this.toolStates.delete(event.properties.partID);
+		this.partMetadata.delete(event.properties.partID);
+		for (const parts of this.messagePartIds.values()) {
+			parts.delete(event.properties.partID);
+		}
+	}
+
+	protected handlePartUpdated(event: EventMessagePartUpdated): void {
+		const part = event.properties.part;
+		if (part.sessionID !== this.sessionId) return;
+		switch (part.type) {
+			case "text":
+				this.logDiagnostic("OPENCODE_PART_TEXT", {
+					partId: part.id,
+					messageId: part.messageID,
+					length: part.text?.length ?? 0,
+				});
+				this.handleTextPart(part);
+				break;
+			case "reasoning":
+				this.logDiagnostic("OPENCODE_PART_REASONING", {
+					partId: part.id,
+					length: part.text?.length ?? 0,
+				});
+				this.handleReasoningPart(part);
+				break;
+			case "tool":
+				this.logDiagnostic("OPENCODE_PART_TOOL", {
+					partId: part.id,
+					tool: part.tool,
+					status: part.state.status,
+				});
+				this.handleToolPart(part);
+				break;
+			case "file":
+			case "snapshot":
+			case "patch":
+			case "agent":
+			case "step-start":
+			case "step-finish":
+			default:
+				break;
+		}
+	}
+
+	protected handleTextPart(part: Extract<Part, { type: "text" }>): void {
+		const previousEntry = this.partMetadata.get(part.id);
+		const previousText = previousEntry?.text ?? "";
+		if (part.text === previousText) return;
+		const delta = part.text.slice(previousText.length);
+		this.partMetadata.set(part.id, {
+			messageId: part.messageID,
+			text: part.text,
+		});
+		let messageParts = this.messagePartIds.get(part.messageID);
+		if (!messageParts) {
+			messageParts = new Set();
+			this.messagePartIds.set(part.messageID, messageParts);
+		}
+		messageParts.add(part.id);
+		if (delta) {
+			const currentBuffer = this.messageBuffers.get(part.messageID) ?? "";
+			this.messageBuffers.set(part.messageID, currentBuffer + delta);
+		}
+		if (!delta) return;
+
+		if (this.includePartialMessages) {
+			this.queue.push({
+				type: "assistant",
+				session_id: this.sessionId ?? undefined,
+				message: {
+					content: [
+						{
+							type: "text",
+							text: delta,
+						},
+					],
+				},
+			});
+		}
+	}
+
+	protected handleReasoningPart(
+		part: Extract<Part, { type: "reasoning" }>,
+	): void {
+		if (!this.includePartialMessages) return;
+		const previous = this.reasoningParts.get(part.id) ?? "";
+		if (part.text === previous) return;
+		const delta = part.text.slice(previous.length);
+		this.reasoningParts.set(part.id, part.text);
+		if (!delta) return;
+		this.queue.push({
+			type: "assistant",
+			session_id: this.sessionId ?? undefined,
+			message: {
+				content: [
+					{
+						type: "text",
+						text: delta,
+					},
+				],
+			},
+		});
+	}
+
+	protected handleToolPart(part: Extract<Part, { type: "tool" }>): void {
+		const previous = this.toolStates.get(part.id);
+		const state = part.state;
+		const mappedName = resolveToolName(
+			part.tool,
+			(state as { input?: unknown }).input,
+		);
+		if (!mappedName) return;
+
+		switch (state.status) {
+			case "running": {
+				if (previous === "running") return;
+				this.toolStates.set(part.id, "running");
+				this.queue.push({
+					type: "assistant",
+					session_id: this.sessionId ?? undefined,
+					message: {
+						content: [
+							{
+								type: "tool_use",
+								name: mappedName,
+								id: part.callID,
+								input: normalizeToolInput(mappedName, state.input),
+							},
+						],
+					},
+				});
+				break;
+			}
+			case "completed": {
+				if (previous === "completed") return;
+				this.toolStates.set(part.id, "completed");
+				this.queue.push({
+					type: "user",
+					session_id: this.sessionId ?? undefined,
+					message: {
+						content: [
+							{
+								type: "tool_result",
+								tool_use_id: part.callID,
+								text: state.output ?? "",
+								content: state.metadata,
+							},
+						],
+					},
+				});
+				break;
+			}
+			case "error": {
+				if (previous === "error") return;
+				this.toolStates.set(part.id, "error");
+				this.queue.push({
+					type: "user",
+					session_id: this.sessionId ?? undefined,
+					message: {
+						content: [
+							{
+								type: "tool_result",
+								tool_use_id: part.callID,
+								text: state.error ?? "Tool call failed",
+								is_error: true,
+							},
+						],
+					},
+				});
+				break;
+			}
+			default: {
+				this.toolStates.set(part.id, state.status as OpenCodeToolStateStatus);
+				break;
+			}
+		}
+	}
+
+	protected async handlePermission(
+		event: EventPermissionUpdated,
+	): Promise<void> {
+		const info = event.properties;
+		if (info.sessionID !== this.sessionId) return;
+		this.logDiagnostic("OPENCODE_PERMISSION_REQUEST", {
+			permissionId: info.id,
+			toolType: info.type,
+		});
+
+		const toolName = resolvePermissionToolName(
+			info.type,
+			info.metadata as Record<string, unknown>,
+		);
+		if (!toolName) {
+			await this.respondToPermission(info, "once");
+			return;
+		}
+
+		if (!this.guard) {
+			await this.respondToPermission(info, "once");
+			return;
+		}
+
+		let decision: ToolPermissionResult;
+		try {
+			decision = await this.guard(toolName, info.metadata ?? {});
+		} catch (error) {
+			await this.respondToPermission(info, "reject");
+			this.queue.push({
+				type: "system",
+				session_id: this.sessionId ?? undefined,
+				subtype: "permission_error",
+				message: {
+					content: `Permission handling failed for ${toolName}: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				},
+			});
+			return;
+		}
+
+		if (decision.behavior === "allow") {
+			await this.respondToPermission(info, "once");
+			return;
+		}
+
+		await this.respondToPermission(info, "reject");
+		this.queue.push({
+			type: "system",
+			session_id: this.sessionId ?? undefined,
+			subtype: "permission_denied",
+			message: {
+				content: decision.message,
+			},
+		});
+	}
+
+	private async respondToPermission(
+		info: Permission,
+		response: "once" | "always" | "reject",
+	): Promise<void> {
+		this.logDiagnostic("OPENCODE_PERMISSION_RESPONSE", {
+			permissionId: info.id,
+			response,
+		});
+		await this.client.postSessionIdPermissionsPermissionId({
+			path: { id: info.sessionID, permissionID: info.id },
+			body: { response },
+			query: this.directory ? { directory: this.directory } : undefined,
+		});
+	}
+
+	protected async enqueuePrompt(text: string): Promise<void> {
+		await this.initialized;
+		this.promptQueue.push(text);
+		void this.processPromptQueue();
+	}
+
+	private async processPromptQueue(): Promise<void> {
+		if (this.processing) return;
+		this.processing = true;
+		while (this.promptQueue.length > 0 && !this.closed) {
+			await this.initialized;
+			const prompt = this.promptQueue.shift();
+			if (!prompt) break;
+			try {
+				await this.sendPrompt(prompt);
+			} catch (error) {
+				this.queue.throw(error);
+				break;
+			}
+		}
+		this.processing = false;
+	}
+
+	protected async sendPrompt(text: string): Promise<void> {
+		if (!this.sessionId) {
+			throw new Error("OpenCode session is not initialized");
+		}
+		await this.initialized;
+		this.logDiagnostic("OPENCODE_PROMPT_SUBMIT", {
+			length: text.length,
+			preview: text.slice(0, 200),
+			agent: this.config.agentName,
+		});
+		const promptBody: {
+			agent?: string;
+			model: { providerID: string; modelID: string };
+			system?: string;
+			parts: Array<{ type: "text"; text: string }>;
+		} = {
+			model: {
+				providerID: this.config.model.providerId,
+				modelID: this.config.model.modelId,
+			},
+			system: this.config.systemPrompt || undefined,
+			parts: [
+				{
+					type: "text" as const,
+					text,
+				},
+			],
+		};
+		if (this.config.agentName) {
+			promptBody.agent = this.config.agentName;
+		}
+
+		const promptResult = await this.client.session.prompt({
+			path: { id: this.sessionId },
+			query: this.directory ? { directory: this.directory } : undefined,
+			body: promptBody,
+		});
+		unwrapData<SessionPromptResponse>(promptResult);
+	}
+
+	async end(): Promise<void> {
+		if (this.closed) return;
+		this.closed = true;
+		try {
+			if (this.eventAbort) {
+				this.eventAbort.abort();
+			}
+			await this.eventLoopPromise;
+		} finally {
+			this.queue.finish();
+			this.logDiagnostic("OPENCODE_SESSION_ENDED", {});
+		}
+	}
+
+	async interrupt(): Promise<void> {
+		await this.initialized;
+		if (!this.sessionId) return;
+		this.logDiagnostic("OPENCODE_SESSION_INTERRUPT", {});
+		await this.client.session.abort({
+			path: { id: this.sessionId },
+			query: this.directory ? { directory: this.directory } : undefined,
+		});
+	}
+
+	[Symbol.asyncIterator](): AsyncIterator<AgentMessage> {
+		return this.queue[Symbol.asyncIterator]();
+	}
+}
+
+class OpenCodeArchitectSession
+	extends OpenCodeSessionBase
+	implements AgentSession
+{
+	constructor(
+		clientFactory: () => Promise<OpenCodeClient>,
+		config: ArchitectSessionConfig,
+	) {
+		super(clientFactory, config);
+	}
+
+	sendMessage(message: string): void {
+		void this.enqueuePrompt(message);
+	}
+
+	async end(): Promise<void> {
+		await super.end();
+	}
+}
+
+class OpenCodeStreamingSession
+	extends OpenCodeSessionBase
+	implements StreamingAgentSession
+{
+	readonly inputStream: AgentInputStream;
+
+	constructor(
+		clientFactory: () => Promise<OpenCodeClient>,
+		streamingConfig: StreamingSessionConfig,
+	) {
+		super(clientFactory, streamingConfig);
+		this.inputStream = {
+			pushText: (text: string) => {
+				void this.enqueuePrompt(text);
+			},
+			end: () => {
+				void this.end();
+			},
+		};
+	}
+
+	async interrupt(): Promise<void> {
+		await super.interrupt();
+	}
+
+	async end(): Promise<void> {
+		await super.end();
+	}
+}
+
+export class OpenCodeProvider extends BaseEmbeddedProvider {
+	readonly name = "opencode";
+
+	private readonly providerConfig: OpenCodeProviderConfig;
+	private serverLease: SharedServerLease | null = null;
+	private clientPromise: Promise<OpenCodeClient> | null = null;
+	private serverConfigApplied = false;
+	private activeProjectPath?: string;
+
+	constructor(config: ProviderConfig) {
+		super(config);
+		const parsed = OpenCodeOptionsSchema.parse(config.options ?? {});
+		const normalizedMcpServers = parsed.mcpServers
+			? Object.entries(parsed.mcpServers).reduce<
+					Record<string, RemoteMcpServerConfig>
+				>((result, [key, value]) => {
+					if (!value) return result;
+					if (typeof value === "string") {
+						result[key] = { url: value, enabled: true };
+						return result;
+					}
+					result[key] = {
+						url: value.url,
+						enabled: value.enabled ?? true,
+						headers: value.headers,
+					};
+					return result;
+				}, {})
+			: undefined;
+		const envStartServer = process.env.OPENCODE_START_SERVER;
+		const startServer =
+			parsed.startServer ??
+			(envStartServer ? envStartServer !== "false" : true);
+		const serverConfig: ServerOptions | undefined = parsed.server
+			? {
+					hostname: parsed.server.hostname ?? DEFAULT_SERVER_HOST,
+					port: parsed.server.port ?? DEFAULT_SERVER_PORT,
+					timeout: parsed.server.timeout ?? DEFAULT_SERVER_TIMEOUT,
+					config: parsed.server.config,
+				}
+			: undefined;
+		const baseUrl =
+			parsed.baseUrl ??
+			process.env.OPENCODE_BASE_URL ??
+			(startServer ? undefined : DEFAULT_BASE_URL);
+		const modelId = parsed.model?.modelId || config.model || DEFAULT_MODEL_ID;
+		const providerId = parsed.model?.providerId || DEFAULT_MODEL_PROVIDER_ID;
+
+		this.providerConfig = {
+			baseUrl,
+			directory: parsed.directory,
+			model: {
+				providerId,
+				modelId,
+			},
+			agents: {
+				// Use OpenCode's built-in "plan" agent for architect role
+				architect: parsed.agents?.architect ?? ENV_AGENT_ARCHITECT ?? "plan",
+				navigator: parsed.agents?.navigator ?? ENV_AGENT_NAVIGATOR,
+				driver: parsed.agents?.driver ?? ENV_AGENT_DRIVER,
+			},
+			startServer,
+			server: serverConfig ?? {
+				hostname: DEFAULT_SERVER_HOST,
+				port: DEFAULT_SERVER_PORT,
+				timeout: DEFAULT_SERVER_TIMEOUT,
+			},
+			mcpServers: normalizedMcpServers,
+		};
+	}
+
+	createSession(options: SessionOptions): AgentSession {
+		const sessionDirectory =
+			this.providerConfig.directory || options.projectPath || undefined;
+		const config: ArchitectSessionConfig = {
+			role: "architect",
+			systemPrompt: options.systemPrompt,
+			directory: sessionDirectory,
+			agentName: this.providerConfig.agents.architect,
+			model: this.providerConfig.model,
+			canUseTool: options.canUseTool as ToolGuard | undefined,
+			includePartialMessages:
+				options.includePartialMessages !== undefined
+					? options.includePartialMessages
+					: false,
+			diagnosticLogger: options.diagnosticLogger,
+		};
+		this.activeProjectPath = sessionDirectory;
+		return new OpenCodeArchitectSession(this.getClient.bind(this), config);
+	}
+
+	createStreamingSession(
+		options: StreamingSessionOptions,
+	): StreamingAgentSession {
+		const sessionDirectory =
+			this.providerConfig.directory || options.projectPath || undefined;
+		const config: StreamingSessionConfig = {
+			role: options.mcpRole,
+			systemPrompt: options.systemPrompt,
+			directory: sessionDirectory,
+			agentName:
+				options.mcpRole === "driver"
+					? this.providerConfig.agents.driver
+					: this.providerConfig.agents.navigator,
+			model: this.providerConfig.model,
+			canUseTool: options.canUseTool as ToolGuard | undefined,
+			includePartialMessages: false,
+			diagnosticLogger: options.diagnosticLogger,
+		};
+		this.activeProjectPath = sessionDirectory;
+		return new OpenCodeStreamingSession(this.getClient.bind(this), config);
+	}
+
+	private buildServerConfig(): Record<string, unknown> | undefined {
+		const base: Record<string, unknown> = this.providerConfig.server?.config
+			? (JSON.parse(
+					JSON.stringify(this.providerConfig.server.config),
+				) as Record<string, unknown>)
+			: {};
+		const mcpServers = this.providerConfig.mcpServers;
+		if (mcpServers && Object.keys(mcpServers).length > 0) {
+			const mergedMcp = (base.mcp as Record<string, unknown> | undefined) ?? {};
+			for (const [name, server] of Object.entries(mcpServers)) {
+				const remoteConfig: Record<string, unknown> = {
+					type: "remote",
+					url: server.url,
+					enabled: server.enabled ?? true,
+				};
+				if (server.headers && Object.keys(server.headers).length > 0) {
+					remoteConfig.headers = server.headers;
+				}
+				mergedMcp[name] = remoteConfig;
+			}
+			base.mcp = mergedMcp;
+			const permission =
+				(base.permission as Record<string, unknown> | undefined) ?? {};
+			if (permission.edit === undefined) {
+				permission.edit = "ask";
+			}
+			if (permission.bash === undefined) {
+				permission.bash = "ask";
+			}
+			base.permission = permission;
+		}
+		const workingDirectory =
+			this.providerConfig.directory || this.activeProjectPath;
+		if (
+			workingDirectory &&
+			typeof workingDirectory === "string" &&
+			workingDirectory.trim().length > 0
+		) {
+			const serverConfig = (base as Record<string, unknown>).directory;
+			if (!serverConfig) {
+				base.directory = workingDirectory;
+			}
+			const pathConfig =
+				(base.path as Record<string, unknown> | undefined) ?? {};
+			if (!pathConfig.directory) {
+				pathConfig.directory = workingDirectory;
+			}
+			if (!pathConfig.worktree) {
+				pathConfig.worktree = workingDirectory;
+			}
+			if (Object.keys(pathConfig).length > 0) {
+				base.path = pathConfig;
+			}
+		}
+		return Object.keys(base).length > 0 ? base : undefined;
+	}
+
+	private async getClient(): Promise<OpenCodeClient> {
+		if (!this.clientPromise) {
+			this.clientPromise = (async () => {
+				let baseUrl = this.providerConfig.baseUrl;
+				let lease: SharedServerLease | null = null;
+				try {
+					if (this.providerConfig.startServer) {
+						const workingDirectory =
+							this.providerConfig.directory || this.activeProjectPath;
+						const serverOptions: ServerOptions = {
+							hostname:
+								this.providerConfig.server?.hostname ?? DEFAULT_SERVER_HOST,
+							port: this.providerConfig.server?.port ?? DEFAULT_SERVER_PORT,
+							timeout:
+								this.providerConfig.server?.timeout ?? DEFAULT_SERVER_TIMEOUT,
+							config: this.buildServerConfig(),
+							workingDirectory,
+						};
+						lease = await acquireSharedServer(serverOptions);
+						this.serverLease = lease;
+						baseUrl = lease.url;
+						this.serverConfigApplied = true;
+					}
+					if (!baseUrl) {
+						throw new Error(
+							"OpenCode provider requires a base URL or startServer configuration",
+						);
+					} else if (
+						!this.providerConfig.startServer &&
+						this.providerConfig.mcpServers &&
+						!this.serverConfigApplied
+					) {
+						console.warn(
+							"[Pair][OpenCode] MCP servers configured but startServer=false. Ensure your external OpenCode instance registers the remote MCP servers.",
+						);
+						this.serverConfigApplied = true;
+					}
+					return createOpencodeClient({
+						baseUrl,
+						responseStyle: "data",
+					});
+				} catch (error) {
+					if (lease) {
+						lease.release();
+					}
+					this.serverLease = null;
+					throw error;
+				}
+			})();
+			this.clientPromise.catch(() => {
+				this.clientPromise = null;
+			});
+		}
+		return this.clientPromise;
+	}
+
+	async cleanup(): Promise<void> {
+		await super.cleanup();
+		if (this.serverLease) {
+			this.serverLease.release();
+			this.serverLease = null;
+		}
+		this.clientPromise = null;
+	}
+}

--- a/src/providers/embedded/openCode.ts
+++ b/src/providers/embedded/openCode.ts
@@ -1222,6 +1222,33 @@ export class OpenCodeProvider extends BaseEmbeddedProvider {
 		return this.clientPromise;
 	}
 
+	getPlanningConfig(task: string): {
+		prompt: string;
+		detectPlanCompletion: (message: any) => string | null;
+	} {
+		return {
+			prompt: `Our task is to: ${task}\n\nPlease create a clear, step-by-step implementation plan tailored to this repository.\n- Focus on concrete steps, specific files, and commands.\n- Keep it concise and actionable.\n- Do not implement changes now.\n\nEnd your response with "PLAN COMPLETE" when you finish the plan.`,
+			detectPlanCompletion: (message) => {
+				// Detect text-based completion
+				if (
+					message.message?.content &&
+					Array.isArray(message.message.content)
+				) {
+					let fullText = "";
+					for (const item of message.message.content) {
+						if (item.type === "text") {
+							fullText += item.text ?? "";
+						}
+					}
+					if (fullText.includes("PLAN COMPLETE")) {
+						return fullText.replace("PLAN COMPLETE", "").trim();
+					}
+				}
+				return null;
+			},
+		};
+	}
+
 	async cleanup(): Promise<void> {
 		await super.cleanup();
 		if (this.serverLease) {

--- a/src/providers/embedded/openCode.ts
+++ b/src/providers/embedded/openCode.ts
@@ -304,8 +304,7 @@ class AsyncMessageQueue<T> implements AsyncIterable<T> {
 			const resolve = this.resolvers.shift();
 			if (resolve) {
 				resolve({
-					// biome-ignore lint/suspicious/noExplicitAny: Async iterator error propagation
-					value: undefined as any,
+					value: undefined,
 					done: true,
 				});
 			}

--- a/src/providers/embedded/openCode.ts
+++ b/src/providers/embedded/openCode.ts
@@ -337,17 +337,6 @@ class AsyncMessageQueue<T> implements AsyncIterable<T> {
 	}
 }
 
-function hasCompletedTimestamp(info: unknown): boolean {
-	if (!info || typeof info !== "object") return false;
-	const time = (info as { time?: unknown }).time;
-	if (!time || typeof time !== "object") return false;
-	if ("completed" in time) {
-		const value = (time as Record<string, unknown>).completed;
-		return value !== undefined && value !== null;
-	}
-	return false;
-}
-
 function unwrapData<T>(
 	result: T | { data: T | undefined; error?: unknown },
 ): T {
@@ -602,7 +591,7 @@ class OpenCodeSessionBase implements AsyncIterable<AgentMessage> {
 			!this.emittedMessages.has(info.id)
 		) {
 			const buffer = this.messageBuffers.get(info.id);
-			if (buffer && buffer.trim()) {
+			if (buffer?.trim()) {
 				this.queue.push({
 					type: "assistant",
 					session_id: this.sessionId ?? undefined,
@@ -660,12 +649,6 @@ class OpenCodeSessionBase implements AsyncIterable<AgentMessage> {
 				});
 				this.handleToolPart(part);
 				break;
-			case "file":
-			case "snapshot":
-			case "patch":
-			case "agent":
-			case "step-start":
-			case "step-finish":
 			default:
 				break;
 		}
@@ -974,13 +957,6 @@ class OpenCodeArchitectSession
 	extends OpenCodeSessionBase
 	implements AgentSession
 {
-	constructor(
-		clientFactory: () => Promise<OpenCodeClient>,
-		config: ArchitectSessionConfig,
-	) {
-		super(clientFactory, config);
-	}
-
 	sendMessage(message: string): void {
 		void this.enqueuePrompt(message);
 	}

--- a/src/providers/embedded/openCode.ts
+++ b/src/providers/embedded/openCode.ts
@@ -313,7 +313,6 @@ class AsyncMessageQueue<T> implements AsyncIterable<T> {
 
 	private async next(): Promise<IteratorResult<T, void>> {
 		if (this.error) {
-			// biome-ignore lint/suspicious/noExplicitAny: Async iterator error propagation
 			throw this.error;
 		}
 

--- a/src/providers/embedded/openCode.ts
+++ b/src/providers/embedded/openCode.ts
@@ -977,6 +977,7 @@ export class OpenCodeProvider extends BaseEmbeddedProvider {
 	private readonly activeCleanups = new Set<() => Promise<void>>();
 	private externalMcpWarningLogged = false;
 	private lastResolvedDirectory?: string;
+	private activeProjectPath?: string;
 
 	constructor(config: ProviderConfig) {
 		super(config);

--- a/src/providers/embedded/openCode/normalization.ts
+++ b/src/providers/embedded/openCode/normalization.ts
@@ -22,6 +22,8 @@ const PERMISSION_TOOL_NAME_MAP: Record<string, string> = {
 	"pair-navigator_navigatorDeny": "mcp__navigator__navigatorDeny",
 	// Special planning tool for architect
 	exitplanmode: "ExitPlanMode",
+	"pair-architect_completePlan": "mcp__architect__completePlan",
+	completeplan: "completePlan",
 };
 
 export function mapPermissionType(type: string): string | null {

--- a/src/providers/embedded/openCode/normalization.ts
+++ b/src/providers/embedded/openCode/normalization.ts
@@ -1,0 +1,164 @@
+const PERMISSION_TOOL_NAME_MAP: Record<string, string> = {
+	bash: "Bash",
+	edit: "Edit",
+	glob: "Glob",
+	grep: "Grep",
+	list: "Glob",
+	multiedit: "MultiEdit",
+	patch: "Patch",
+	read: "Read",
+	todoread: "TodoRead",
+	todowrite: "TodoWrite",
+	task: "Task",
+	test: "Test",
+	webfetch: "WebFetch",
+	websearch: "WebSearch",
+	write: "Write",
+	"pair-driver_driverRequestReview": "mcp__driver__driverRequestReview",
+	"pair-driver_driverRequestGuidance": "mcp__driver__driverRequestGuidance",
+	"pair-navigator_navigatorCodeReview": "mcp__navigator__navigatorCodeReview",
+	"pair-navigator_navigatorComplete": "mcp__navigator__navigatorComplete",
+	"pair-navigator_navigatorApprove": "mcp__navigator__navigatorApprove",
+	"pair-navigator_navigatorDeny": "mcp__navigator__navigatorDeny",
+	// Special planning tool for architect
+	exitplanmode: "ExitPlanMode",
+};
+
+export function mapPermissionType(type: string): string | null {
+	return PERMISSION_TOOL_NAME_MAP[type] ?? null;
+}
+
+export function mapPartToolName(tool: string): string | null {
+	return PERMISSION_TOOL_NAME_MAP[tool] ?? tool;
+}
+
+export function resolveToolName(tool: string, input: unknown): string | null {
+	let candidate = tool;
+	if (
+		candidate === "invalid" &&
+		input &&
+		typeof input === "object" &&
+		"tool" in (input as Record<string, unknown>)
+	) {
+		const fallback = (input as Record<string, unknown>).tool;
+		if (typeof fallback === "string" && fallback.trim().length > 0) {
+			candidate = fallback;
+		}
+	}
+
+	if (candidate === "invalid") {
+		return null;
+	}
+
+	return mapPartToolName(candidate);
+}
+
+export function resolvePermissionToolName(
+	type: string,
+	metadata?: Record<string, unknown> | null,
+): string | null {
+	const primary = mapPermissionType(type);
+	if (primary && primary !== "invalid") {
+		return primary;
+	}
+
+	if (metadata && typeof metadata === "object") {
+		const fallback = metadata.tool;
+		if (typeof fallback === "string" && fallback.trim().length > 0) {
+			const mappedFallback = mapPermissionType(fallback);
+			if (mappedFallback && mappedFallback !== "invalid") {
+				return mappedFallback;
+			}
+			if (fallback !== "invalid") {
+				return fallback;
+			}
+		}
+	}
+
+	return null;
+}
+
+function normalizeToolBaseName(tool: string): string {
+	if (tool.startsWith("mcp__")) {
+		const parts = tool.split("__");
+		return parts[parts.length - 1].toLowerCase();
+	}
+	if (tool.startsWith("pair-driver_")) {
+		return tool.slice("pair-driver_".length).toLowerCase();
+	}
+	if (tool.startsWith("pair-navigator_")) {
+		return tool.slice("pair-navigator_".length).toLowerCase();
+	}
+	return tool.toLowerCase();
+}
+
+export function normalizeToolInput(
+	tool: string,
+	input: unknown,
+): Record<string, unknown> {
+	if (!input || typeof input !== "object") {
+		return {};
+	}
+	const original = input as Record<string, unknown>;
+	const normalized: Record<string, unknown> = { ...original };
+	const baseName = normalizeToolBaseName(tool);
+
+	const coalescePath = (...keys: string[]): string | undefined => {
+		for (const key of keys) {
+			const value = original[key];
+			if (typeof value === "string" && value.trim().length > 0) {
+				return value;
+			}
+		}
+		return undefined;
+	};
+
+	if (baseName === "read") {
+		const filePath = coalescePath(
+			"file_path",
+			"filePath",
+			"path",
+			"file",
+			"target",
+		);
+		if (filePath) {
+			normalized.file_path = filePath;
+		}
+	} else if (baseName === "edit") {
+		const filePath = coalescePath("file_path", "filePath", "path", "file");
+		if (filePath) normalized.file_path = filePath;
+		const oldString = original.old_string ?? original.oldString;
+		if (typeof oldString === "string") {
+			normalized.old_string = oldString;
+		}
+		const newString = original.new_string ?? original.newString;
+		if (typeof newString === "string") {
+			normalized.new_string = newString;
+		}
+	} else if (baseName === "write") {
+		const filePath = coalescePath("file_path", "filePath", "path", "file");
+		if (filePath) normalized.file_path = filePath;
+	} else if (baseName === "multiedit") {
+		const filePath = coalescePath("file_path", "filePath", "path", "file");
+		if (filePath) normalized.file_path = filePath;
+		const edits = original.edits;
+		if (Array.isArray(edits)) {
+			normalized.edit_count = edits.length;
+		}
+	} else if (baseName === "glob" || baseName === "list") {
+		const pathValue = coalescePath("path", "directory", "dir");
+		if (pathValue) normalized.path = pathValue;
+		if (typeof original.pattern === "string") {
+			normalized.pattern = original.pattern;
+		}
+	}
+
+	return normalized;
+}
+
+export const __openCodeTestUtils = {
+	mapPartToolName,
+	normalizeToolInput,
+	resolveToolName,
+	resolvePermissionToolName,
+};

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -3,6 +3,7 @@
  */
 
 import { ClaudeCodeProvider } from "./embedded/claudeCode.js";
+import { OpenCodeProvider } from "./embedded/openCode.js";
 import type {
 	AgentProvider,
 	AgentProviderFactory,
@@ -23,6 +24,7 @@ export class DefaultAgentProviderFactory implements AgentProviderFactory {
 	constructor() {
 		// Register default providers
 		this.registerProvider("claude-code", ClaudeCodeProvider);
+		this.registerProvider("opencode", OpenCodeProvider);
 	}
 
 	/**

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,6 +4,7 @@
 
 export { BaseEmbeddedProvider } from "./embedded/base.js";
 export { ClaudeCodeProvider } from "./embedded/claudeCode.js";
+export { OpenCodeProvider } from "./embedded/openCode.js";
 export {
 	agentProviderFactory,
 	DefaultAgentProviderFactory,

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -196,6 +196,14 @@ export interface EmbeddedAgentProvider extends AgentProvider {
 	createStreamingSession(
 		options: StreamingSessionOptions,
 	): StreamingAgentSession;
+
+	/**
+	 * Get provider-specific planning configuration
+	 */
+	getPlanningConfig(task: string): {
+		prompt: string;
+		detectPlanCompletion: (message: AgentMessage) => string | null;
+	};
 }
 
 /**

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -32,6 +32,11 @@ export interface AgentMessage {
 /**
  * Provider configuration for each agent role
  */
+export type DiagnosticLogger = (
+	event: string,
+	data: Record<string, unknown>,
+) => void;
+
 export interface ProviderConfig {
 	type: "claude-code" | "codex" | "opencode" | string;
 	apiKey?: string;
@@ -143,6 +148,7 @@ export interface SessionOptions {
 	permissionMode?: "default" | "plan";
 	includePartialMessages?: boolean;
 	disallowedTools?: string[];
+	diagnosticLogger?: DiagnosticLogger;
 }
 
 /**
@@ -170,6 +176,7 @@ export interface StreamingSessionOptions {
 	>;
 	disallowedTools?: string[];
 	includePartialMessages?: boolean;
+	diagnosticLogger?: DiagnosticLogger;
 }
 
 /**

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -67,6 +67,13 @@ export interface PairProgrammingState {
 	currentActivity: string;
 	phase?: SessionPhase;
 	quitState?: "normal" | "confirm";
+	providers: AgentProviders;
+}
+
+export interface AgentProviders {
+	architect: string;
+	navigator: string;
+	driver: string;
 }
 
 export interface MessageEntry {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -42,7 +42,7 @@ export const DEFAULT_CONFIG: AppConfig = {
 	model: undefined, // Use CLI default
 	sessionHardLimitMs: 30 * 60 * 1000, // 30 minutes
 	enableSyncStatus: true, // Enable by default
-	architectProvider: "opencode",
+	architectProvider: "claude-code",
 	navigatorProvider: "opencode",
 	driverProvider: "claude-code",
 };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -42,8 +42,8 @@ export const DEFAULT_CONFIG: AppConfig = {
 	model: undefined, // Use CLI default
 	sessionHardLimitMs: 30 * 60 * 1000, // 30 minutes
 	enableSyncStatus: true, // Enable by default
-	architectProvider: "claude-code",
-	navigatorProvider: "claude-code",
+	architectProvider: "opencode",
+	navigatorProvider: "opencode",
 	driverProvider: "claude-code",
 };
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -44,7 +44,7 @@ export const DEFAULT_CONFIG: AppConfig = {
 	enableSyncStatus: true, // Enable by default
 	architectProvider: "claude-code",
 	navigatorProvider: "opencode",
-	driverProvider: "claude-code",
+	driverProvider: "opencode",
 };
 
 /**

--- a/src/utils/systemLine.ts
+++ b/src/utils/systemLine.ts
@@ -12,13 +12,32 @@ export interface SystemLineFormat {
 // - navigatorCodeReview -> • (cyan)
 // - navigatorComplete -> ⏹ (greenBright)
 // - driverRequestReview -> text only (no symbol override)
+function toNavigatorToolId(tool: string): string | null {
+	if (tool.startsWith("mcp__navigator__")) return tool;
+	if (tool.startsWith("pair-navigator_")) {
+		const suffix = tool.slice("pair-navigator_".length);
+		return `mcp__navigator__${suffix}`;
+	}
+	return null;
+}
+
+function toDriverToolId(tool: string): string | null {
+	if (tool.startsWith("mcp__driver__")) return tool;
+	if (tool.startsWith("pair-driver_")) {
+		const suffix = tool.slice("pair-driver_".length);
+		return `mcp__driver__${suffix}`;
+	}
+	return null;
+}
+
 export function formatSystemLine(
 	role: Role,
 	tool: string,
 	// biome-ignore lint/suspicious/noExplicitAny: tool parameters are dynamic
 	params?: any,
 ): SystemLineFormat | null {
-	if (role === "navigator" && tool.startsWith("mcp__navigator__")) {
+	const navigatorTool = toNavigatorToolId(tool);
+	if (role === "navigator" && navigatorTool) {
 		const comment =
 			params && typeof params.comment === "string" ? params.comment : "";
 		const summary =
@@ -26,28 +45,28 @@ export function formatSystemLine(
 				? (params as any).summary
 				: "";
 
-		if (tool === "mcp__navigator__navigatorApprove") {
+		if (navigatorTool === "mcp__navigator__navigatorApprove") {
 			return {
 				content: `Approved${comment ? `: ${comment}` : ""}`,
 				symbol: "✓",
 				symbolColor: "#00ff00",
 			};
 		}
-		if (tool === "mcp__navigator__navigatorDeny") {
+		if (navigatorTool === "mcp__navigator__navigatorDeny") {
 			return {
 				content: `Denied${comment ? `: ${comment}` : ""}`,
 				symbol: "x",
 				symbolColor: "#ff0000",
 			};
 		}
-		if (tool === "mcp__navigator__navigatorCodeReview") {
+		if (navigatorTool === "mcp__navigator__navigatorCodeReview") {
 			return {
 				content: `Code Review${comment ? `: ${comment}` : ""}`,
 				symbol: "•",
 				symbolColor: "cyan",
 			};
 		}
-		if (tool === "mcp__navigator__navigatorComplete") {
+		if (navigatorTool === "mcp__navigator__navigatorComplete") {
 			return {
 				content: `Completed${summary ? `: ${summary}` : ""}`,
 				symbol: "⏹",
@@ -56,12 +75,19 @@ export function formatSystemLine(
 		}
 	}
 
-	if (role === "driver" && tool.startsWith("mcp__driver__")) {
+	const driverTool = toDriverToolId(tool);
+	if (role === "driver" && driverTool) {
 		const ctx =
 			params && typeof params.context === "string" ? params.context : "";
-		if (tool === "mcp__driver__driverRequestReview") {
+		if (driverTool === "mcp__driver__driverRequestReview") {
 			return {
 				content: `🔍 Review requested${ctx ? `: ${ctx}` : ""}`,
+				symbol: "",
+			};
+		}
+		if (driverTool === "mcp__driver__driverRequestGuidance") {
+			return {
+				content: `🧭 Guidance requested${ctx ? `: ${ctx}` : ""}`,
 				symbol: "",
 			};
 		}

--- a/src/utils/timeouts.ts
+++ b/src/utils/timeouts.ts
@@ -5,7 +5,7 @@
 // Configurable timeout values (in milliseconds)
 export const TIMEOUT_CONFIG = {
 	TOOL_COMPLETION: Number(process.env.PAIR_TOOL_TIMEOUT_MS) || 120000, // 2 minutes
-	PERMISSION_REQUEST: Number(process.env.PAIR_PERMISSION_TIMEOUT_MS) || 15000, // 15 seconds
+	PERMISSION_REQUEST: Number(process.env.PAIR_PERMISSION_TIMEOUT_MS) || 45000, // 45 seconds
 } as const;
 
 /**

--- a/test/integration/providers/mixedProviders.integration.test.ts
+++ b/test/integration/providers/mixedProviders.integration.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Simple integration tests for provider scenarios
+ */
+
+import { describe, test, expect } from 'vitest';
+import { agentProviderFactory } from '../../../src/providers/factory.js';
+import { validateConfig } from '../../../src/utils/config.js';
+import type { AppConfig } from '../../../src/utils/config.js';
+
+describe('Provider Integration', () => {
+	test('should create different provider types', () => {
+		const claudeProvider = agentProviderFactory.createProvider({
+			type: 'claude-code'
+		});
+
+		const openCodeProvider = agentProviderFactory.createProvider({
+			type: 'opencode'
+		});
+
+		expect(claudeProvider.name).toBe('claude-code');
+		expect(openCodeProvider.name).toBe('opencode');
+		expect(claudeProvider.type).toBe('embedded');
+		expect(openCodeProvider.type).toBe('embedded');
+	});
+
+	test('should validate mixed provider configuration', () => {
+		const config: AppConfig = {
+			navigatorMaxTurns: 50,
+			driverMaxTurns: 20,
+			maxPromptLength: 10000,
+			maxPromptFileSize: 100 * 1024,
+			sessionHardLimitMs: 30 * 60 * 1000,
+			enableSyncStatus: true,
+			architectProvider: 'claude-code',
+			navigatorProvider: 'opencode',
+			driverProvider: 'claude-code',
+		};
+
+		const availableProviders = agentProviderFactory.getAvailableProviders();
+		expect(() => validateConfig(config, availableProviders)).not.toThrow();
+	});
+
+	test('should reject unknown provider types', () => {
+		const config: AppConfig = {
+			navigatorMaxTurns: 50,
+			driverMaxTurns: 20,
+			maxPromptLength: 10000,
+			maxPromptFileSize: 100 * 1024,
+			sessionHardLimitMs: 30 * 60 * 1000,
+			enableSyncStatus: true,
+			architectProvider: 'invalid-provider',
+			navigatorProvider: 'claude-code',
+			driverProvider: 'claude-code',
+		};
+
+		const availableProviders = agentProviderFactory.getAvailableProviders();
+		expect(() => validateConfig(config, availableProviders)).toThrow();
+	});
+});

--- a/test/unit/navigatorPermission.test.ts
+++ b/test/unit/navigatorPermission.test.ts
@@ -110,6 +110,75 @@ describe('Navigator permission approvals', () => {
     );
   });
 
+  it('processes commands only after tool_result is received', async () => {
+    // This test verifies that commands are created only when tool_result arrives
+    // Include both tool_use and tool_result in the correct order
+    const messages: AgentMessage[] = [
+      {
+        type: 'assistant',
+        session_id: 'ses_test',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'mcp__navigator__navigatorApprove',
+              id: 'tool_1',
+              input: { comment: 'Approving edit' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        session_id: 'ses_test',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool_1',
+              content: [],
+            },
+          ],
+        },
+      },
+    ];
+
+    const provider = new StubProvider(messages);
+    const logger = { logEvent: vi.fn() } as any;
+    const navigator = new Navigator(
+      'system prompt',
+      ['Read'],
+      5,
+      '/repo',
+      logger,
+      provider,
+      'http://localhost/mcp/navigator',
+    );
+
+    const result = await navigator.reviewPermission({
+      driverTranscript: 'Editing file',
+      toolName: 'Edit',
+      input: { filePath: '/repo/file.txt' },
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.comment).toBe('Approving edit');
+
+    // Verify that NAVIGATOR_TOOL_PENDING was logged before NAVIGATOR_TOOL_RESULT_OBSERVED
+    const logCalls = logger.logEvent.mock.calls;
+    const pendingIndex = logCalls.findIndex(call => call[0] === 'NAVIGATOR_TOOL_PENDING');
+    const resultIndex = logCalls.findIndex(call => call[0] === 'NAVIGATOR_TOOL_RESULT_OBSERVED');
+
+    expect(pendingIndex).toBeGreaterThanOrEqual(0);
+    expect(resultIndex).toBeGreaterThan(pendingIndex);
+
+    // Verify batch was only delivered after tool_result
+    expect(logger.logEvent).toHaveBeenCalledWith(
+      'NAVIGATOR_BATCH_RESULT',
+      expect.objectContaining({ commandCount: 1 }),
+    );
+  });
+
   it('treats approve tool as code review pass outside permission flow', async () => {
     const messages: AgentMessage[] = [
       {

--- a/test/unit/navigatorPermission.test.ts
+++ b/test/unit/navigatorPermission.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  AgentInputStream,
+  AgentMessage,
+  AgentSession,
+  EmbeddedAgentProvider,
+  StreamingAgentSession,
+  StreamingSessionOptions,
+  SessionOptions,
+} from '../../src/providers/types.js';
+import { Navigator } from '../../src/conversations/Navigator.js';
+
+class StubStreamingSession implements StreamingAgentSession {
+  sessionId: string | null = null;
+  inputStream: AgentInputStream = {
+    pushText: vi.fn(),
+    end: vi.fn(),
+  };
+
+  constructor(private readonly messages: AgentMessage[]) {}
+
+  async interrupt(): Promise<void> {}
+
+  async *[Symbol.asyncIterator](): AsyncIterator<AgentMessage> {
+    for (const message of this.messages) {
+      if (message.session_id && !this.sessionId) {
+        this.sessionId = message.session_id;
+      }
+      yield message;
+    }
+  }
+}
+
+class StubProvider implements EmbeddedAgentProvider {
+  readonly name = 'stub';
+  readonly type = 'embedded' as const;
+
+  constructor(private readonly messages: AgentMessage[]) {}
+
+  createSession(_options: SessionOptions): AgentSession {
+    throw new Error('not implemented');
+  }
+
+  createStreamingSession(_options: StreamingSessionOptions): StreamingAgentSession {
+    return new StubStreamingSession(this.messages);
+  }
+
+  getPlanningConfig() {
+    return {
+      prompt: '',
+      detectPlanCompletion: () => null,
+    };
+  }
+}
+
+describe('Navigator permission approvals', () => {
+  it('resolves approval batches without result messages', async () => {
+    const messages: AgentMessage[] = [
+      {
+        type: 'assistant',
+        session_id: 'ses_test',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'mcp__navigator__navigatorApprove',
+              id: 'tool_1',
+              input: { comment: 'Looks good' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        session_id: 'ses_test',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool_1',
+              content: [],
+            },
+          ],
+        },
+      },
+    ];
+
+    const provider = new StubProvider(messages);
+    const logger = { logEvent: vi.fn() } as any;
+    const navigator = new Navigator(
+      'system prompt',
+      ['Read'],
+      5,
+      '/repo',
+      logger,
+      provider,
+      'http://localhost/mcp/navigator',
+    );
+
+    const result = await navigator.reviewPermission({
+      driverTranscript: 'Testing approve flow',
+      toolName: 'Edit',
+      input: { filePath: '/repo/file.txt' },
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(logger.logEvent).toHaveBeenCalledWith(
+      'NAVIGATOR_BATCH_RESULT',
+      expect.objectContaining({ commandCount: 1 }),
+    );
+  });
+
+  it('treats approve tool as code review pass outside permission flow', async () => {
+    const messages: AgentMessage[] = [
+      {
+        type: 'assistant',
+        session_id: 'ses_test',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'mcp__navigator__navigatorApprove',
+              id: 'tool_approval',
+              input: { comment: 'Looks good overall.' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        session_id: 'ses_test',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool_approval',
+              content: [],
+            },
+          ],
+        },
+      },
+    ];
+
+    const provider = new StubProvider(messages);
+    const logger = { logEvent: vi.fn() } as any;
+    const navigator = new Navigator(
+      'system prompt',
+      ['Read'],
+      5,
+      '/repo',
+      logger,
+      provider,
+      'http://localhost/mcp/navigator',
+    );
+
+    await navigator.initialize('Test task', 'Test plan');
+
+    const commands = await navigator.processDriverMessage(
+      'Please review the latest changes.',
+    );
+
+    expect(commands).not.toBeNull();
+    expect(commands).toHaveLength(1);
+    expect(commands![0]).toEqual({
+      type: 'code_review',
+      pass: true,
+      comment: 'Looks good overall.',
+    });
+  });
+});

--- a/test/unit/openCodeNormalize.test.ts
+++ b/test/unit/openCodeNormalize.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+
+import {
+	mapPartToolName,
+	normalizeToolInput,
+	resolvePermissionToolName,
+	resolveToolName,
+} from "../../src/providers/embedded/openCode/normalization.js";
+
+describe("OpenCode tool normalization", () => {
+	it("maps pair-* navigator tools to canonical names", () => {
+		expect(mapPartToolName("pair-navigator_navigatorComplete")).toBe(
+			"mcp__navigator__navigatorComplete",
+		);
+		expect(mapPartToolName("pair-driver_driverRequestReview")).toBe(
+			"mcp__driver__driverRequestReview",
+		);
+	});
+
+	it("normalizes read input paths", () => {
+		const input = { path: "/tmp/data.txt" };
+		const normalized = normalizeToolInput("Read", input);
+		expect(normalized.file_path).toBe("/tmp/data.txt");
+		// original keys remain
+		expect(normalized.path).toBe("/tmp/data.txt");
+	});
+
+	it("normalizes edit inputs with camel case keys", () => {
+		const input = {
+			filePath: "src/index.ts",
+			oldString: "foo",
+			newString: "bar",
+		};
+		const normalized = normalizeToolInput("Edit", input);
+		expect(normalized.file_path).toBe("src/index.ts");
+		expect(normalized.old_string).toBe("foo");
+		expect(normalized.new_string).toBe("bar");
+	});
+
+	it("preserves write paths", () => {
+		const normalized = normalizeToolInput("Write", { path: "docs/readme.md" });
+		expect(normalized.file_path).toBe("docs/readme.md");
+	});
+
+	it("records multi-edit edit count", () => {
+		const normalized = normalizeToolInput("MultiEdit", {
+			path: "src/app.ts",
+			edits: [{}, {}, {}],
+		});
+		expect(normalized.file_path).toBe("src/app.ts");
+		expect(normalized.edit_count).toBe(3);
+	});
+
+	it("rescues invalid tool names from fallback input", () => {
+		expect(
+			resolveToolName("invalid", {
+				tool: "pair-driver_driverRequestReview",
+			}),
+		).toBe("mcp__driver__driverRequestReview");
+	});
+
+	it("returns null when invalid tool provides no fallback", () => {
+		expect(resolveToolName("invalid", {})).toBeNull();
+	});
+
+	it("resolves permission tool fallback from metadata", () => {
+		expect(
+			resolvePermissionToolName("invalid", {
+				tool: "pair-driver_driverRequestGuidance",
+			}),
+		).toBe("mcp__driver__driverRequestGuidance");
+	});
+
+	it("returns null when permission metadata lacks usable tool", () => {
+		expect(resolvePermissionToolName("invalid", null)).toBeNull();
+	});
+});

--- a/test/unit/permissionFlow.test.ts
+++ b/test/unit/permissionFlow.test.ts
@@ -252,7 +252,8 @@ describe("Navigator Command Parsing", () => {
 		);
 	});
 
-	it("should parse approval commands correctly", () => {
+	it("should parse approval commands correctly during permission flow", () => {
+		(navigator as any).inPermissionApproval = true;
 		const command = (navigator as any).convertMcpToolToCommand(
 			"mcp__navigator__navigatorApprove",
 			{ comment: "LGTM" }
@@ -264,7 +265,22 @@ describe("Navigator Command Parsing", () => {
 		});
 	});
 
-	it("should parse denial commands correctly", () => {
+	it("should map approval to code review outside permission flow", () => {
+		(navigator as any).inPermissionApproval = false;
+		const command = (navigator as any).convertMcpToolToCommand(
+			"mcp__navigator__navigatorApprove",
+			{ comment: "LGTM" }
+		);
+
+		expect(command).toEqual({
+			type: "code_review",
+			pass: true,
+			comment: "LGTM",
+		});
+	});
+
+	it("should parse denial commands correctly during permission flow", () => {
+		(navigator as any).inPermissionApproval = true;
 		const command = (navigator as any).convertMcpToolToCommand(
 			"mcp__navigator__navigatorDeny",
 			{ comment: "Needs more testing" }
@@ -272,6 +288,20 @@ describe("Navigator Command Parsing", () => {
 
 		expect(command).toEqual({
 			type: "deny",
+			comment: "Needs more testing",
+		});
+	});
+
+	it("should map denial to failed code review outside permission flow", () => {
+		(navigator as any).inPermissionApproval = false;
+		const command = (navigator as any).convertMcpToolToCommand(
+			"mcp__navigator__navigatorDeny",
+			{ comment: "Needs more testing" }
+		);
+
+		expect(command).toEqual({
+			type: "code_review",
+			pass: false,
 			comment: "Needs more testing",
 		});
 	});

--- a/test/unit/providers/openCode.test.ts
+++ b/test/unit/providers/openCode.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { OpenCodeProvider } from '../../../src/providers/embedded/openCode.js';
+import type { StreamingSessionOptions } from '../../../src/providers/types.js';
+
+interface ServerHandleRecord {
+  options: any;
+  handle: { url: string; close: ReturnType<typeof vi.fn> };
+}
+
+interface ClientHandleRecord {
+  baseUrl: string;
+}
+
+const serverHandles: ServerHandleRecord[] = [];
+const clientHandles: ClientHandleRecord[] = [];
+
+function createEmptyAsyncStream() {
+  return (async function* () {
+    return;
+  })();
+}
+
+function createMockClient(baseUrl: string) {
+  const sessionId = `session-${Math.random().toString(36).slice(2, 8)}`;
+
+  return {
+    __baseUrl: baseUrl,
+    session: {
+      create: vi.fn().mockResolvedValue({
+        data: { id: sessionId, title: 'pair-session' },
+      }),
+      prompt: vi.fn().mockResolvedValue({ data: {} }),
+      abort: vi.fn().mockResolvedValue({ data: {} }),
+    },
+    event: {
+      subscribe: vi.fn().mockResolvedValue({ stream: createEmptyAsyncStream() }),
+    },
+    tool: {
+      ids: vi.fn().mockResolvedValue({ data: [] }),
+    },
+    path: {
+      get: vi.fn().mockResolvedValue({
+        data: { state: 'ready', worktree: '', directory: '' },
+      }),
+    },
+    project: {
+      current: vi.fn().mockResolvedValue({
+        data: { id: 'proj', worktree: '' },
+      }),
+    },
+    permission: {
+      update: vi.fn().mockResolvedValue({ data: {} }),
+    },
+    message: {
+      get: vi.fn().mockResolvedValue({ data: {} }),
+    },
+  };
+}
+
+async function flushAsync(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+vi.mock('@opencode-ai/sdk', () => {
+  return {
+    createOpencodeServer: vi.fn(async (options: any) => {
+      const handle = {
+        url: `http://127.0.0.1:${9000 + serverHandles.length}`,
+        close: vi.fn(),
+      };
+      serverHandles.push({ options, handle });
+      return handle;
+    }),
+    createOpencodeClient: vi.fn((args: { baseUrl: string }) => {
+      const client = createMockClient(args.baseUrl);
+      clientHandles.push({ baseUrl: args.baseUrl });
+      return client as any;
+    }),
+  };
+});
+
+import { createOpencodeClient, createOpencodeServer } from '@opencode-ai/sdk';
+
+const mockedCreateOpencodeServer = vi.mocked(createOpencodeServer);
+const mockedCreateOpencodeClient = vi.mocked(createOpencodeClient);
+
+function buildStreamingOptions(
+  overrides: Partial<StreamingSessionOptions>,
+): StreamingSessionOptions {
+  return {
+    systemPrompt: overrides.systemPrompt ?? 'prompt',
+    allowedTools: overrides.allowedTools ?? ['all'],
+    additionalMcpTools: overrides.additionalMcpTools ?? [],
+    maxTurns: overrides.maxTurns ?? 5,
+    projectPath: overrides.projectPath ?? '/repo',
+    mcpServerUrl: overrides.mcpServerUrl ?? 'http://localhost:4097/mcp/role',
+    embeddedMcpServer: overrides.embeddedMcpServer,
+    mcpRole: overrides.mcpRole ?? 'driver',
+    canUseTool: overrides.canUseTool,
+    disallowedTools: overrides.disallowedTools ?? [],
+    includePartialMessages: overrides.includePartialMessages,
+    diagnosticLogger: overrides.diagnosticLogger,
+  };
+}
+
+beforeEach(() => {
+  serverHandles.length = 0;
+  clientHandles.length = 0;
+  vi.clearAllMocks();
+  delete process.env.OPENCODE_START_SERVER;
+  delete process.env.OPENCODE_BASE_URL;
+});
+
+afterEach(() => {
+  delete process.env.OPENCODE_START_SERVER;
+  delete process.env.OPENCODE_BASE_URL;
+});
+
+describe('OpenCodeProvider', () => {
+  it('starts a dedicated server for driver sessions with project working directory', async () => {
+    process.env.OPENCODE_START_SERVER = 'true';
+
+    const provider = new OpenCodeProvider({ type: 'opencode' });
+    const session = provider.createStreamingSession(
+      buildStreamingOptions({
+        projectPath: '/repo/driver',
+        mcpServerUrl: 'http://localhost:7000/mcp/driver',
+        mcpRole: 'driver',
+      }),
+    );
+
+    await flushAsync();
+    expect(mockedCreateOpencodeServer).toHaveBeenCalledTimes(1);
+
+    const serverCall = serverHandles[0];
+    expect(serverCall.options.port).toBe(0);
+    expect(serverCall.options.config?.path?.worktree).toBe('/repo/driver');
+    expect(serverCall.options.config?.path?.directory).toBe('/repo/driver');
+    expect(serverCall.options.config?.mcp?.['pair-driver']).toEqual({
+      type: 'remote',
+      url: 'http://localhost:7000/mcp/driver',
+      enabled: true,
+    });
+    expect(clientHandles[0]?.baseUrl).toBe(serverCall.handle.url);
+
+    await session.end();
+    await flushAsync();
+    expect(serverCall.handle.close).toHaveBeenCalledTimes(1);
+    await provider.cleanup();
+  });
+
+  it('starts separate servers for navigator and driver roles with distinct MCP configs', async () => {
+    process.env.OPENCODE_START_SERVER = 'true';
+
+    const provider = new OpenCodeProvider({ type: 'opencode' });
+    const driverSession = provider.createStreamingSession(
+      buildStreamingOptions({
+        projectPath: '/repo/driver',
+        mcpServerUrl: 'http://localhost:7010/mcp/driver',
+        mcpRole: 'driver',
+      }),
+    );
+    const navigatorSession = provider.createStreamingSession(
+      buildStreamingOptions({
+        projectPath: '/repo/navigator',
+        mcpServerUrl: 'http://localhost:7011/mcp/navigator',
+        mcpRole: 'navigator',
+      }),
+    );
+
+    await flushAsync();
+    expect(mockedCreateOpencodeServer).toHaveBeenCalledTimes(2);
+
+    const driverCall = serverHandles.find((record) => record.options.config?.mcp?.['pair-driver']);
+    const navigatorCall = serverHandles.find((record) => record.options.config?.mcp?.['pair-navigator']);
+
+    expect(driverCall?.options.config?.mcp?.['pair-driver']?.url).toBe('http://localhost:7010/mcp/driver');
+    expect(navigatorCall?.options.config?.mcp?.['pair-navigator']?.url).toBe('http://localhost:7011/mcp/navigator');
+    expect(driverCall && navigatorCall && driverCall.handle).not.toBe(navigatorCall?.handle);
+
+    await driverSession.end();
+    await navigatorSession.end();
+
+    await flushAsync();
+    expect(driverCall?.handle.close).toHaveBeenCalledTimes(1);
+    expect(navigatorCall?.handle.close).toHaveBeenCalledTimes(1);
+
+    await provider.cleanup();
+  });
+
+  it('does not start a server when startServer is disabled and uses provided base URL', async () => {
+    process.env.OPENCODE_START_SERVER = 'false';
+    process.env.OPENCODE_BASE_URL = 'http://external-opencode';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const provider = new OpenCodeProvider({ type: 'opencode' });
+    const session = provider.createStreamingSession(
+      buildStreamingOptions({
+        projectPath: '/repo/external',
+        mcpServerUrl: 'http://localhost:7012/mcp/driver',
+        mcpRole: 'driver',
+      }),
+    );
+
+    await flushAsync();
+    expect(mockedCreateOpencodeClient).toHaveBeenCalledTimes(1);
+    expect(mockedCreateOpencodeServer).not.toHaveBeenCalled();
+    expect(clientHandles[0]?.baseUrl).toBe('http://external-opencode');
+    expect(warnSpy).toHaveBeenCalled();
+
+    await session.end();
+    await provider.cleanup();
+    warnSpy.mockRestore();
+  });
+});

--- a/test/unit/timeouts.test.ts
+++ b/test/unit/timeouts.test.ts
@@ -8,7 +8,7 @@ import { TIMEOUT_CONFIG, TimeoutManager } from '../../src/utils/timeouts.js';
 describe('TIMEOUT_CONFIG', () => {
 	it('should have default timeout values', () => {
 		expect(TIMEOUT_CONFIG.TOOL_COMPLETION).toBe(120000); // 2 minutes
-		expect(TIMEOUT_CONFIG.PERMISSION_REQUEST).toBe(15000); // 15 seconds
+		expect(TIMEOUT_CONFIG.PERMISSION_REQUEST).toBe(45000); // 45 seconds
 	});
 
 	it('should allow environment variable overrides', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,11 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': new URL('./src', import.meta.url).pathname,
+      '@opencode-ai/sdk': new URL('./node_modules/@opencode-ai/sdk/dist/index.js', import.meta.url).pathname,
     },
+    conditions: ['import', 'node'],
+  },
+  define: {
+    'process.env.NODE_ENV': '"test"',
   },
 });


### PR DESCRIPTION
This pull request introduces support for multiple agent providers in the Pair CLI tool, allowing each role (architect, navigator, driver) to run on either Claude Code or OpenCode. It updates the documentation, adds provider selection and configuration, improves logging and diagnostic capabilities, and enhances tool normalization for better compatibility. The UI is updated to display the active providers for each role.

**Multi-provider support and configuration:**

* The `README.md` is updated to describe how each agent role can use either the Claude Code or OpenCode provider, including new environment variables for provider selection and OpenCode configuration. Example usage and setup instructions are added. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R7) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R114) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L121-R153) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R175-R181)
* The OpenCode SDK is added as a dependency in `package.json` to enable OpenCode agent support.

**Provider-aware session management and prompts:**

* The `Architect`, `Driver`, and `Navigator` classes now accept and log the provider name for diagnostic purposes. The Architect's initial prompt and plan completion detection are adjusted for OpenCode, supporting both tool-based and text-based plan completion. [[1]](diffhunk://#diff-1f46ad66df9bf7e08614c8b911aa4fe5e8fc513770a700353af16f8f8986a752R46) [[2]](diffhunk://#diff-1f46ad66df9bf7e08614c8b911aa4fe5e8fc513770a700353af16f8f8986a752R57-R70) [[3]](diffhunk://#diff-1f46ad66df9bf7e08614c8b911aa4fe5e8fc513770a700353af16f8f8986a752L96-R124) [[4]](diffhunk://#diff-1f46ad66df9bf7e08614c8b911aa4fe5e8fc513770a700353af16f8f8986a752L113-R133) [[5]](diffhunk://#diff-1f46ad66df9bf7e08614c8b911aa4fe5e8fc513770a700353af16f8f8986a752L134-R168) [[6]](diffhunk://#diff-48a2e7bf22e675d8bc763f235653e54462f8a58cff5a9bdef4828e133171a3c5R192-R198) [[7]](diffhunk://#diff-cbca2325d82ac76a3f3b816129f72e02a1382dde1b03397c02b22b0cc65d7798R250-R256)

**Tool normalization and compatibility:**

* Tool name normalization functions are added to both the Driver and Navigator classes to support tool names from both Claude Code and OpenCode, ensuring consistent command handling. [[1]](diffhunk://#diff-48a2e7bf22e675d8bc763f235653e54462f8a58cff5a9bdef4828e133171a3c5L529-R537) [[2]](diffhunk://#diff-48a2e7bf22e675d8bc763f235653e54462f8a58cff5a9bdef4828e133171a3c5R553-R562) [[3]](diffhunk://#diff-cbca2325d82ac76a3f3b816129f72e02a1382dde1b03397c02b22b0cc65d7798L580-R588) [[4]](diffhunk://#diff-cbca2325d82ac76a3f3b816129f72e02a1382dde1b03397c02b22b0cc65d7798R606-R623)

**User interface improvements:**

* The footer and main UI now display the provider for each agent role, making it clear which backend is in use for architect, navigator, and driver. Props and state are updated to support this display. [[1]](diffhunk://#diff-0dce242c6c493ad784b03374bef9541bc63a42693fdb79e88c6dda5e76fbac04L4-R4) [[2]](diffhunk://#diff-0dce242c6c493ad784b03374bef9541bc63a42693fdb79e88c6dda5e76fbac04R13) [[3]](diffhunk://#diff-0dce242c6c493ad784b03374bef9541bc63a42693fdb79e88c6dda5e76fbac04R23) [[4]](diffhunk://#diff-0dce242c6c493ad784b03374bef9541bc63a42693fdb79e88c6dda5e76fbac04R40-R54) [[5]](diffhunk://#diff-0dce242c6c493ad784b03374bef9541bc63a42693fdb79e88c6dda5e76fbac04L49-R66) [[6]](diffhunk://#diff-6874d2318be967c7fae4278d0819fba438444a288260165fec98cc908cb26339R46) [[7]](diffhunk://#diff-e634567fa0884b45a6b06623351b48fbc86e773bde23e1484f2a422ae903a65dR50-R56)

**Minor enhancements and fixes:**

* Improved robustness in message handling and UI transitions, including handling undefined roles and minor formatting tweaks. [[1]](diffhunk://#diff-6ce750d9e596521f4d7ed3bc8d2e51cf57c55459881fa5515dc1e66d61373258R103) [[2]](diffhunk://#diff-e634567fa0884b45a6b06623351b48fbc86e773bde23e1484f2a422ae903a65dL160-R165) [[3]](diffhunk://#diff-e634567fa0884b45a6b06623351b48fbc86e773bde23e1484f2a422ae903a65dR178)

These changes make Pair more flexible and extensible, allowing seamless integration and orchestration of different coding agent providers in a collaborative session.